### PR TITLE
BuildToolsをxcworkspaceから削除

### DIFF
--- a/charcoal.xcworkspace/contents.xcworkspacedata
+++ b/charcoal.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:BuildTools">
-   </FileRef>
-   <FileRef
       location = "group:Examples/SwiftUISample/SwiftUISample.xcodeproj">
    </FileRef>
    <FileRef


### PR DESCRIPTION
## 解決したいこと
- Xcodeを起動したときに無駄なSPMのfetchが走るのを防ぐ

## やったこと
- BuildToolsはcharcoalのビルドには不要で、CLI用なのでworkspaceからは消す

## やらないこと
