### PR TITLE
GitHub ActionsのRubyのバージョンを上げる

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
           bundler-cache: true
 
       - name: Bundle install


### PR DESCRIPTION
## 解決したいこと
- #21 でDangerのgemのアップデートで失敗している

## やったこと
- Rubyのバージョンをひとまず2.7に上げる

## やらないこと
- 3.0以上にするのは一旦やらない

## 動作確認環境
- 
