### PR TITLE
Primaryボタンは色の指定を可能にした

### DIFF
--- a/Examples/SwiftUISample/SwiftUISample/Contents/ButtonsView.swift
+++ b/Examples/SwiftUISample/SwiftUISample/Contents/ButtonsView.swift
@@ -63,6 +63,15 @@ struct ButtonsView: View {
                         .charcoalLinkButton()
                         .disabled(true)
                 }
+
+                let premiumColor = Color(hue: 0.097, saturation: 0.91, brightness: 0.99)
+                VStack(spacing: 8) {
+                    Button("Premium") {}
+                        .charcoalPrimaryButton(primaryColor: premiumColor)
+                    Button("Premium") {}
+                        .charcoalPrimaryButton(primaryColor: premiumColor)
+                        .disabled(true)
+                }
             }
             .padding(16)
             .frame(maxWidth: .infinity)

--- a/Examples/UIKitSample/UIKitSample/Storyboards/Buttons.storyboard
+++ b/Examples/UIKitSample/UIKitSample/Storyboards/Buttons.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="848"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="DVi-Mx-59J">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="858"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="959"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kN2-FR-jrI" customClass="CharcoalPrimaryMButton" customModule="Charcoal">
                                                 <rect key="frame" x="129" y="0.0" width="156.5" height="34.5"/>
@@ -87,8 +87,26 @@
                                                 <rect key="frame" x="152" y="757.5" width="110.5" height="34.5"/>
                                                 <buttonConfiguration key="configuration" style="plain" title="Link Button"/>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gBE-2a-Bja" customClass="CharcoalPrimaryMButton" customModule="Charcoal">
+                                                <rect key="frame" x="66.5" y="808" width="281" height="34.5"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="Primary Button M(Premium Color)"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="primaryColor">
+                                                        <color key="value" red="1" green="0.62083333333333335" blue="0.089999999999999969" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PVu-zD-AIp" customClass="CharcoalPrimaryMButton" customModule="Charcoal">
+                                                <rect key="frame" x="66.5" y="858.5" width="281" height="34.5"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="Primary Button M(Premium Color)"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="primaryColor">
+                                                        <color key="value" red="1" green="0.62083333333333335" blue="0.089999999999999969" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cb8-0d-GAd" customClass="CharcoalSwitchingButton" customModule="Charcoal">
-                                                <rect key="frame" x="87" y="808" width="240" height="50"/>
+                                                <rect key="frame" x="87" y="909" width="240" height="50"/>
                                             </view>
                                         </subviews>
                                     </stackView>
@@ -133,6 +151,9 @@
         <designable name="JGW-w8-qTA">
             <size key="intrinsicContentSize" width="152.5" height="34.5"/>
         </designable>
+        <designable name="PVu-zD-AIp">
+            <size key="intrinsicContentSize" width="281" height="34.5"/>
+        </designable>
         <designable name="Q3p-Wk-xz0">
             <size key="intrinsicContentSize" width="149" height="34.5"/>
         </designable>
@@ -144,6 +165,9 @@
         </designable>
         <designable name="f54-h5-6k3">
             <size key="intrinsicContentSize" width="153" height="34.5"/>
+        </designable>
+        <designable name="gBE-2a-Bja">
+            <size key="intrinsicContentSize" width="281" height="34.5"/>
         </designable>
         <designable name="jJN-Vo-2RY">
             <size key="intrinsicContentSize" width="152.5" height="34.5"/>

--- a/Sources/Charcoal/SwiftUI/Components/Buttons/CharcoalPrimaryButton.swift
+++ b/Sources/Charcoal/SwiftUI/Components/Buttons/CharcoalPrimaryButton.swift
@@ -7,6 +7,7 @@ struct CharcoalPrimaryButtonStyleView: View {
     let isEnabled: Bool
     let size: CharcoalButtonSize
     let isFixed: Bool
+    let color: Color
 
     var body: some View {
         label
@@ -15,7 +16,7 @@ struct CharcoalPrimaryButtonStyleView: View {
             .padding(size == .medium ? 24 : 16)
             .frame(maxWidth: isFixed ? nil : .infinity)
             .frame(height: size == .medium ? 40 : 32)
-            .background(Color(CharcoalAsset.ColorPaletteGenerated.brand.color))
+            .background(color)
             .opacity(isEnabled ? 1.0 : 0.32)
             .overlay(
                 Rectangle()
@@ -30,6 +31,7 @@ struct CharcoalPrimaryButtonStyleIos15: ButtonStyle {
     @Environment(\.isEnabled) var isEnabled
     let size: CharcoalButtonSize
     let isFixed: Bool
+    let color: Color
 
     func makeBody(configuration: Self.Configuration) -> some View {
         CharcoalPrimaryButtonStyleView(
@@ -37,7 +39,8 @@ struct CharcoalPrimaryButtonStyleIos15: ButtonStyle {
             isPressed: configuration.isPressed,
             isEnabled: isEnabled,
             size: size,
-            isFixed: isFixed
+            isFixed: isFixed,
+            color: color
         )
     }
 }
@@ -47,6 +50,7 @@ struct CharcoalPrimaryButtonStyle: ButtonStyle {
     let isEnabled: Bool
     let size: CharcoalButtonSize
     let isFixed: Bool
+    let color: Color
 
     func makeBody(configuration: Self.Configuration) -> some View {
         CharcoalPrimaryButtonStyleView(
@@ -54,7 +58,8 @@ struct CharcoalPrimaryButtonStyle: ButtonStyle {
             isPressed: configuration.isPressed,
             isEnabled: isEnabled,
             size: size,
-            isFixed: isFixed
+            isFixed: isFixed,
+            color: color
         )
     }
 }
@@ -64,19 +69,24 @@ struct CharcoalPrimaryButtonStyleModifier: ViewModifier {
     @Environment(\.isEnabled) var isEnabled
     let size: CharcoalButtonSize
     let isFixed: Bool
+    let color: Color
 
     func body(content: Content) -> some View {
         if #available(iOS 15, *) {
-            content.buttonStyle(CharcoalPrimaryButtonStyleIos15(size: size, isFixed: isFixed))
+            content.buttonStyle(CharcoalPrimaryButtonStyleIos15(size: size, isFixed: isFixed, color: color))
         } else {
-            content.buttonStyle(CharcoalPrimaryButtonStyle(isEnabled: isEnabled, size: size, isFixed: isFixed))
+            content.buttonStyle(CharcoalPrimaryButtonStyle(isEnabled: isEnabled, size: size, isFixed: isFixed, color: color))
         }
     }
 }
 
 @available(iOS 13, *)
 public extension View {
-    func charcoalPrimaryButton(size: CharcoalButtonSize = .medium, isFixed: Bool = true) -> some View {
-        return modifier(CharcoalPrimaryButtonStyleModifier(size: size, isFixed: isFixed))
+    func charcoalPrimaryButton(
+        size: CharcoalButtonSize = .medium,
+        isFixed: Bool = true,
+        color: Color = Color(CharcoalAsset.ColorPaletteGenerated.brand.color)
+    ) -> some View {
+        return modifier(CharcoalPrimaryButtonStyleModifier(size: size, isFixed: isFixed, color: color))
     }
 }

--- a/Sources/Charcoal/SwiftUI/Components/Buttons/CharcoalPrimaryButton.swift
+++ b/Sources/Charcoal/SwiftUI/Components/Buttons/CharcoalPrimaryButton.swift
@@ -7,7 +7,7 @@ struct CharcoalPrimaryButtonStyleView: View {
     let isEnabled: Bool
     let size: CharcoalButtonSize
     let isFixed: Bool
-    let color: Color
+    let primaryColor: Color
 
     var body: some View {
         label
@@ -16,7 +16,7 @@ struct CharcoalPrimaryButtonStyleView: View {
             .padding(size == .medium ? 24 : 16)
             .frame(maxWidth: isFixed ? nil : .infinity)
             .frame(height: size == .medium ? 40 : 32)
-            .background(color)
+            .background(primaryColor)
             .opacity(isEnabled ? 1.0 : 0.32)
             .overlay(
                 Rectangle()
@@ -31,7 +31,7 @@ struct CharcoalPrimaryButtonStyleIos15: ButtonStyle {
     @Environment(\.isEnabled) var isEnabled
     let size: CharcoalButtonSize
     let isFixed: Bool
-    let color: Color
+    let primaryColor: Color
 
     func makeBody(configuration: Self.Configuration) -> some View {
         CharcoalPrimaryButtonStyleView(
@@ -40,7 +40,7 @@ struct CharcoalPrimaryButtonStyleIos15: ButtonStyle {
             isEnabled: isEnabled,
             size: size,
             isFixed: isFixed,
-            color: color
+            primaryColor: primaryColor
         )
     }
 }
@@ -50,7 +50,7 @@ struct CharcoalPrimaryButtonStyle: ButtonStyle {
     let isEnabled: Bool
     let size: CharcoalButtonSize
     let isFixed: Bool
-    let color: Color
+    let primaryColor: Color
 
     func makeBody(configuration: Self.Configuration) -> some View {
         CharcoalPrimaryButtonStyleView(
@@ -59,7 +59,7 @@ struct CharcoalPrimaryButtonStyle: ButtonStyle {
             isEnabled: isEnabled,
             size: size,
             isFixed: isFixed,
-            color: color
+            primaryColor: primaryColor
         )
     }
 }
@@ -69,13 +69,13 @@ struct CharcoalPrimaryButtonStyleModifier: ViewModifier {
     @Environment(\.isEnabled) var isEnabled
     let size: CharcoalButtonSize
     let isFixed: Bool
-    let color: Color
+    let primaryColor: Color
 
     func body(content: Content) -> some View {
         if #available(iOS 15, *) {
-            content.buttonStyle(CharcoalPrimaryButtonStyleIos15(size: size, isFixed: isFixed, color: color))
+            content.buttonStyle(CharcoalPrimaryButtonStyleIos15(size: size, isFixed: isFixed, primaryColor: primaryColor))
         } else {
-            content.buttonStyle(CharcoalPrimaryButtonStyle(isEnabled: isEnabled, size: size, isFixed: isFixed, color: color))
+            content.buttonStyle(CharcoalPrimaryButtonStyle(isEnabled: isEnabled, size: size, isFixed: isFixed, primaryColor: primaryColor))
         }
     }
 }
@@ -85,8 +85,8 @@ public extension View {
     func charcoalPrimaryButton(
         size: CharcoalButtonSize = .medium,
         isFixed: Bool = true,
-        color: Color = Color(CharcoalAsset.ColorPaletteGenerated.brand.color)
+        primaryColor: Color = Color(CharcoalAsset.ColorPaletteGenerated.brand.color)
     ) -> some View {
-        return modifier(CharcoalPrimaryButtonStyleModifier(size: size, isFixed: isFixed, color: color))
+        return modifier(CharcoalPrimaryButtonStyleModifier(size: size, isFixed: isFixed, primaryColor: primaryColor))
     }
 }

--- a/Sources/Charcoal/UIKit/Components/Buttons/CharcoalPrimaryMButton.swift
+++ b/Sources/Charcoal/UIKit/Components/Buttons/CharcoalPrimaryMButton.swift
@@ -5,7 +5,7 @@ public class CharcoalPrimaryMButton: UIButton, CharcoalButton {
     @IBInspectable
     public var isFixed: Bool = false
     @IBInspectable
-    public var color: UIColor = CharcoalAsset.ColorPaletteGenerated.brand.color
+    public var primaryColor: UIColor = CharcoalAsset.ColorPaletteGenerated.brand.color
 
     override public var intrinsicContentSize: CGSize {
         let contentSize = super.intrinsicContentSize
@@ -53,14 +53,14 @@ public class CharcoalPrimaryMButton: UIButton, CharcoalButton {
         if #available(iOS 15, *) {
             configuration = generateUIButtonConfiguration(
                 textColor: CharcoalAsset.ColorPaletteGenerated.text5.color,
-                enabledBackgroundColor: color,
+                enabledBackgroundColor: primaryColor,
                 pressedOverlayColor: CharcoalAsset.ColorPaletteGenerated.surface10.color,
                 size: .medium
             )
         } else {
             setupButtonStyle(
                 textColor: CharcoalAsset.ColorPaletteGenerated.text5.color,
-                enabledBackgroundColor: color,
+                enabledBackgroundColor: primaryColor,
                 pressedOverlayColor: CharcoalAsset.ColorPaletteGenerated.surface10.color,
                 size: .medium
             )

--- a/Sources/Charcoal/UIKit/Components/Buttons/CharcoalPrimaryMButton.swift
+++ b/Sources/Charcoal/UIKit/Components/Buttons/CharcoalPrimaryMButton.swift
@@ -4,6 +4,8 @@ import UIKit
 public class CharcoalPrimaryMButton: UIButton, CharcoalButton {
     @IBInspectable
     public var isFixed: Bool = false
+    @IBInspectable
+    public var color: UIColor = CharcoalAsset.ColorPaletteGenerated.brand.color
 
     override public var intrinsicContentSize: CGSize {
         let contentSize = super.intrinsicContentSize
@@ -51,14 +53,14 @@ public class CharcoalPrimaryMButton: UIButton, CharcoalButton {
         if #available(iOS 15, *) {
             configuration = generateUIButtonConfiguration(
                 textColor: CharcoalAsset.ColorPaletteGenerated.text5.color,
-                enabledBackgroundColor: CharcoalAsset.ColorPaletteGenerated.brand.color,
+                enabledBackgroundColor: color,
                 pressedOverlayColor: CharcoalAsset.ColorPaletteGenerated.surface10.color,
                 size: .medium
             )
         } else {
             setupButtonStyle(
                 textColor: CharcoalAsset.ColorPaletteGenerated.text5.color,
-                enabledBackgroundColor: CharcoalAsset.ColorPaletteGenerated.brand.color,
+                enabledBackgroundColor: color,
                 pressedOverlayColor: CharcoalAsset.ColorPaletteGenerated.surface10.color,
                 size: .medium
             )

--- a/Sources/Charcoal/UIKit/Components/Buttons/CharcoalPrimarySButton.swift
+++ b/Sources/Charcoal/UIKit/Components/Buttons/CharcoalPrimarySButton.swift
@@ -4,6 +4,8 @@ import UIKit
 public class CharcoalPrimarySButton: UIButton, CharcoalButton {
     @IBInspectable
     public var isFixed: Bool = false
+    @IBInspectable
+    public var color: UIColor = CharcoalAsset.ColorPaletteGenerated.brand.color
 
     override public var intrinsicContentSize: CGSize {
         let contentSize = super.intrinsicContentSize
@@ -51,14 +53,14 @@ public class CharcoalPrimarySButton: UIButton, CharcoalButton {
         if #available(iOS 15, *) {
             configuration = generateUIButtonConfiguration(
                 textColor: CharcoalAsset.ColorPaletteGenerated.text5.color,
-                enabledBackgroundColor: CharcoalAsset.ColorPaletteGenerated.brand.color,
+                enabledBackgroundColor: color,
                 pressedOverlayColor: CharcoalAsset.ColorPaletteGenerated.surface10.color,
                 size: .small
             )
         } else {
             setupButtonStyle(
                 textColor: CharcoalAsset.ColorPaletteGenerated.text5.color,
-                enabledBackgroundColor: CharcoalAsset.ColorPaletteGenerated.brand.color,
+                enabledBackgroundColor: color,
                 pressedOverlayColor: CharcoalAsset.ColorPaletteGenerated.surface10.color,
                 size: .small
             )

--- a/Sources/Charcoal/UIKit/Components/Buttons/CharcoalPrimarySButton.swift
+++ b/Sources/Charcoal/UIKit/Components/Buttons/CharcoalPrimarySButton.swift
@@ -5,7 +5,7 @@ public class CharcoalPrimarySButton: UIButton, CharcoalButton {
     @IBInspectable
     public var isFixed: Bool = false
     @IBInspectable
-    public var color: UIColor = CharcoalAsset.ColorPaletteGenerated.brand.color
+    public var primaryColor: UIColor = CharcoalAsset.ColorPaletteGenerated.brand.color
 
     override public var intrinsicContentSize: CGSize {
         let contentSize = super.intrinsicContentSize
@@ -53,14 +53,14 @@ public class CharcoalPrimarySButton: UIButton, CharcoalButton {
         if #available(iOS 15, *) {
             configuration = generateUIButtonConfiguration(
                 textColor: CharcoalAsset.ColorPaletteGenerated.text5.color,
-                enabledBackgroundColor: color,
+                enabledBackgroundColor: primaryColor,
                 pressedOverlayColor: CharcoalAsset.ColorPaletteGenerated.surface10.color,
                 size: .small
             )
         } else {
             setupButtonStyle(
                 textColor: CharcoalAsset.ColorPaletteGenerated.text5.color,
-                enabledBackgroundColor: color,
+                enabledBackgroundColor: primaryColor,
                 pressedOverlayColor: CharcoalAsset.ColorPaletteGenerated.surface10.color,
                 size: .small
             )


### PR DESCRIPTION
## 解決したいこと
- pixiv以外のサービス(コミック, Premium, ...)などでブランドカラーが異なる場合があり、そのような場合でもCharcoalが使えるようにする

## やったこと
- Primaryボタンの色を任意で置き換えられるようにした
  - デザインガイドライン上、一部のUI(Primaryボタンの背景色など)は色の書き換えが許容されている

## やらないこと
- この問題を根本的に解決する仕組み(テーマの導入など)

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

UIKit | SwiftUI
---|---
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-20 at 18 51 45](https://user-images.githubusercontent.com/4125422/220071917-78a9be6b-3369-4e8d-901f-db5fa0f9ba36.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-20 at 18 51 02](https://user-images.githubusercontent.com/4125422/220071934-9cd1625c-bb60-4706-a698-95a82ae3d699.png)

## 動作確認環境
- Simulator
