### PR TITLE
ForkしたPRでDangerが動かないのを修正

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## 解決したいこと
- ForkしたPRでDangerが動かないのを修正

## やったこと
- fetch depthを0に設定
