### PR TITLE
ワーニング 'argument must be an integer literal' を修正

### DIFF
--- a/Examples/SwiftUISample/SwiftUISample/Contents/ColorsView.swift
+++ b/Examples/SwiftUISample/SwiftUISample/Contents/ColorsView.swift
@@ -38,9 +38,9 @@ struct ColorsView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
-                ForEach(0 ..< colors.count / columns + 1) { row in
+                ForEach(0 ..< colors.count / columns + 1, id: \.self) { row in
                     HStack(spacing: 16) {
-                        ForEach(0 ..< columns) { column in
+                        ForEach(0 ..< columns, id: \.self) { column in
                             if row * 4 + column < colors.count {
                                 Rectangle()
                                     .frame(width: 64, height: 64)


### PR DESCRIPTION
## 解決したいこと
- `ColoersView`における`ForEach`で発生しているワーニング`argument must be an integer literal`を解消したい

## やったこと
- ForEachの引数に対して`id: \.self`を追加した
- ForEachのドキュメントは[こちら](https://developer.apple.com/documentation/swiftui/foreach/init(_:content:)-6db7u)

## やらないこと
- なし

## スクリーンショット
- なし

## 動作確認環境
- Xcode14.1
- iOS16.3.1
