### PR TITLE
Fix toggle style

### DIFF
--- a/CharcoalUIKitSample/Sources/CharcoalUIKitSample/Storyboards/Selections.storyboard
+++ b/CharcoalUIKitSample/Sources/CharcoalUIKitSample/Storyboards/Selections.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,22 +18,22 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Toggle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Cx-Xv-hCS" customClass="CharcoalTypography12" customModule="Charcoal">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Toggle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Cx-Xv-hCS" customClass="CharcoalTypography14" customModule="Charcoal">
                                 <rect key="frame" x="20" y="83" width="52" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" name="text1"/>
                                 <nil key="highlightedColor"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isBold" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isBold" value="NO"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Toggle Disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EYT-pm-K8e" customClass="CharcoalTypography12" customModule="Charcoal">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Toggle Disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EYT-pm-K8e" customClass="CharcoalTypography14" customModule="Charcoal">
                                 <rect key="frame" x="20" y="128" width="122" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" name="text1"/>
                                 <nil key="highlightedColor"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isBold" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isBold" value="NO"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Z8-Al-hhS" customClass="CharcoalSwitch" customModule="Charcoal">
@@ -82,6 +83,9 @@
         </designable>
     </designables>
     <resources>
+        <namedColor name="text1">
+            <color red="0.12156862765550613" green="0.12156862765550613" blue="0.12156862765550613" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Sources/Charcoal/SwiftUI/Components/CharcoalToggle.swift
+++ b/Sources/Charcoal/SwiftUI/Components/CharcoalToggle.swift
@@ -45,7 +45,9 @@ struct CharcoalToggleStyle: ToggleStyle {
 
     func makeBody(configuration: Self.Configuration) -> some View {
         HStack {
-            configuration.label.foregroundColor(Color(CharcoalAsset.ColorPaletteGenerated.text1.color))
+            configuration.label
+                .font(.system(size: 14))
+                .charcoalOnSurfaceText1()
             Spacer()
             CharcoalToggleWrapper(isOn: configuration.$isOn)
                 .padding(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 4))

--- a/Sources/Charcoal/SwiftUI/Components/CharcoalToggle.swift
+++ b/Sources/Charcoal/SwiftUI/Components/CharcoalToggle.swift
@@ -46,7 +46,7 @@ struct CharcoalToggleStyle: ToggleStyle {
     func makeBody(configuration: Self.Configuration) -> some View {
         HStack {
             configuration.label
-                .font(.system(size: 14))
+                .font(.system(size: CGFloat(charcoalFoundation.typography.size.the14.fontSize)))
                 .charcoalOnSurfaceText1()
             Spacer()
             CharcoalToggleWrapper(isOn: configuration.$isOn)

--- a/Sources/Charcoal/SwiftUI/Components/CharcoalToggle.swift
+++ b/Sources/Charcoal/SwiftUI/Components/CharcoalToggle.swift
@@ -46,7 +46,7 @@ struct CharcoalToggleStyle: ToggleStyle {
     func makeBody(configuration: Self.Configuration) -> some View {
         HStack {
             configuration.label
-                .font(.system(size: CGFloat(charcoalFoundation.typography.size.the14.fontSize)))
+                .charcoalTypography14Regular()
                 .charcoalOnSurfaceText1()
             Spacer()
             CharcoalToggleWrapper(isOn: configuration.$isOn)

--- a/Sources/Charcoal/SwiftUI/Components/CharcoalToggle.swift
+++ b/Sources/Charcoal/SwiftUI/Components/CharcoalToggle.swift
@@ -45,7 +45,7 @@ struct CharcoalToggleStyle: ToggleStyle {
 
     func makeBody(configuration: Self.Configuration) -> some View {
         HStack {
-            configuration.label
+            configuration.label.foregroundColor(Color(CharcoalAsset.ColorPaletteGenerated.text1.color))
             Spacer()
             CharcoalToggleWrapper(isOn: configuration.$isOn)
                 .padding(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 4))


### PR DESCRIPTION
## 解決したいこと
SwiftUIのToggleのlabelをCharcoalのスタイルにする

## やったこと
UIKit & SwiftUI のToggleのlabelは変更した

## やらないこと
-

## スクリーンショット

### SwiftUI
<img width="680" alt="image" src="https://github.com/pixiv/charcoal-ios/assets/141606011/c865902d-710c-4bd4-91ef-1b06b226e77a">

### UIKit

<img width="620" alt="image" src="https://github.com/pixiv/charcoal-ios/assets/141606011/c0f76584-402e-43bc-8747-88cf302dd92f">


## 動作確認環境
iOS 13 - iOS 16
