### PR TITLE
Fix accessibility Image(charcoalIcon:)

### DIFF
--- a/Sources/Charcoal/SwiftUI/Images/Image.swift
+++ b/Sources/Charcoal/SwiftUI/Images/Image.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-extension Image {
+public extension Image {
     @inlinable init(charocalIcon: CharcoalAsset.Images) {
         self.init(asset: charocalIcon.imageAsset)
     }


### PR DESCRIPTION
## 解決したいこと
- `Image(charcoalIcon:)` がinternalになっていてアクセスできない

## やったこと
- publicを付与

## やらないこと
- 

## 動作確認環境
- SwiftUICatalog
