### PR TITLE
Refine icons wall Scrollview appearance to match screen width

### DIFF
--- a/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/IconsView.swift
+++ b/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/IconsView.swift
@@ -44,6 +44,8 @@ struct IconsView: View {
                     }
                 }
             }
+            .padding(16)
+            .frame(maxWidth: .infinity)
         }
         .navigationBarTitle("Icons")
     }


### PR DESCRIPTION
## 解決したいこと
Icons WallのScrollViewがScreenと同じ幅にならない問題を修正する

## 動作確認環境
iOS 14 - iOS 17
