### PR TITLE
Use isSingleLine to fix unexpected height change of TextField

### DIFF
--- a/Sources/CharcoalSwiftUI/Components/CharcoalTextField.swift
+++ b/Sources/CharcoalSwiftUI/Components/CharcoalTextField.swift
@@ -26,13 +26,13 @@ struct CharcoalTextFieldStyle: TextFieldStyle {
             }
             HStack(spacing: 10) {
                 configuration
-                    .charcoalTypography14Regular()
+                    .charcoalTypography14Regular(isSingleLine: true)
                     .focused($isFocused)
                     .frame(maxWidth: .infinity)
                     .charcoalOnSurfaceText2()
                 if !countLabel.isEmpty {
                     Text(countLabel)
-                        .charcoalTypography14Regular()
+                        .charcoalTypography14Regular(isSingleLine: true)
                         // swiftlint:disable line_length
                         .foregroundStyle(charcoalColor: hasError ? .assertive : .text3)
                 }


### PR DESCRIPTION
## 解決したいこと
それ以前に、内容を入力してから削除すると、TextFieldの高さが変わる可能性があります。また、countLabelが表示されるときも高さが変わることがあります。