### PR TITLE
Fix typo charocal to charcoal

### DIFF
--- a/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/BalloonsView.swift
+++ b/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/BalloonsView.swift
@@ -18,7 +18,7 @@ public struct BalloonsView: View {
                     Button {
                         isPresented.toggle()
                     } label: {
-                        Image(charocalIcon: .question24)
+                        Image(charcoalIcon: .question24)
                     }
                     .charcoalBalloon(
                         isPresenting: $isPresented,
@@ -31,7 +31,7 @@ public struct BalloonsView: View {
                     Button {
                         isPresented2.toggle()
                     } label: {
-                        Image(charocalIcon: .question24)
+                        Image(charcoalIcon: .question24)
                     }
                     .charcoalBalloon(isPresenting: $isPresented2, text: "作品中の特定単語について、単語変換をして読めるようになりました") {
                         Button(action: {}, label: {
@@ -46,7 +46,7 @@ public struct BalloonsView: View {
                     Button {
                         isPresented3.toggle()
                     } label: {
-                        Image(charocalIcon: .question24)
+                        Image(charcoalIcon: .question24)
                     }
                     .charcoalBalloon(
                         isPresenting: $isPresented3,
@@ -60,7 +60,7 @@ public struct BalloonsView: View {
                 Button {
                     isPresented4.toggle()
                 } label: {
-                    Image(charocalIcon: .question24)
+                    Image(charcoalIcon: .question24)
                 }
                 .charcoalBalloon(
                     isPresenting: $isPresented4,

--- a/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/IconsView.swift
+++ b/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/IconsView.swift
@@ -27,7 +27,7 @@ struct IconsView: View {
                                             .frame(width: 64, height: 64)
                                             .cornerRadius(8)
                                             .foregroundStyle(charcoalColor: .background2)
-                                        Image(charocalIcon: icon)
+                                        Image(charcoalIcon: icon)
                                     }
                                     Text(icon.description)
                                         .lineLimit(2)

--- a/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/ToastsView.swift
+++ b/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/ToastsView.swift
@@ -122,7 +122,7 @@ public struct ToastsView: View {
                         Button {
                             isPresentingToast2 = false
                         } label: {
-                            Image(charocalIcon: .remove16)
+                            Image(charcoalIcon: .remove16)
                                 .renderingMode(.template)
                         }
                     }
@@ -146,7 +146,7 @@ public struct ToastsView: View {
                         Button {
                             isPresentingToast3 = false
                         } label: {
-                            Image(charocalIcon: .remove16)
+                            Image(charcoalIcon: .remove16)
                                 .renderingMode(.template)
                         }
                     }

--- a/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/TooltipsView.swift
+++ b/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/TooltipsView.swift
@@ -18,7 +18,7 @@ public struct TooltipsView: View {
                     Button(action: {
                         isPresented.toggle()
                     }, label: {
-                        Image(charocalIcon: .question16)
+                        Image(charcoalIcon: .question16)
                     }).charcoalTooltip(isPresenting: $isPresented, text: "Tooltip created by Charcoal")
                 }
 
@@ -27,7 +27,7 @@ public struct TooltipsView: View {
                     Button(action: {
                         isPresented2.toggle()
                     }, label: {
-                        Image(charocalIcon: .question16)
+                        Image(charcoalIcon: .question16)
                     }).charcoalTooltip(isPresenting: $isPresented2, text: "Tooltip created by Charcoal and here is testing it's multiple line feature")
                 }
 
@@ -37,7 +37,7 @@ public struct TooltipsView: View {
                     Button(action: {
                         isPresented4.toggle()
                     }, label: {
-                        Image(charocalIcon: .question16)
+                        Image(charcoalIcon: .question16)
                     }).charcoalTooltip(isPresenting: $isPresented4, text: "Tooltip created by Charcoal and here is testing Auto-Positioning")
                 }
             }
@@ -47,7 +47,7 @@ public struct TooltipsView: View {
                 Button(action: {
                     isPresented3.toggle()
                 }, label: {
-                    Image(charocalIcon: .question16)
+                    Image(charcoalIcon: .question16)
                 }).charcoalTooltip(isPresenting: $isPresented3, text: "Tooltip created by Charcoal and here is testing Auto-Positioning")
             }
         }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Button("Default Button M") {}
 ```
 
 #### UIKit
-デフォルトでは、CharocalUIKitはUITraitCollectionのpreferredContentSizeCategory属性に従いますので、UITraitCollectionを変更することでSizeCategoryを指定できます。
+デフォルトでは、CharcoalUIKitはUITraitCollectionのpreferredContentSizeCategory属性に従いますので、UITraitCollectionを変更することでSizeCategoryを指定できます。
 
 ```swift
 let trait = UITraitCollection(preferredContentSizeCategory: .large)

--- a/Sources/CharcoalSwiftUI/Components/Balloon/CharcoalBalloon.swift
+++ b/Sources/CharcoalSwiftUI/Components/Balloon/CharcoalBalloon.swift
@@ -146,7 +146,7 @@ struct CharcoalBalloon<ActionContent: View>: CharcoalPopupProtocol, CharcoalToas
                                     .fixedSize(horizontal: false, vertical: true)
                                     .foregroundColor(Color(CharcoalAsset.ColorPaletteGenerated.text5.color))
 
-                                Image(charocalIcon: .remove16)
+                                Image(charcoalIcon: .remove16)
                                     .renderingMode(.template)
                                     .foregroundColor(Color.white)
                                     .frame(width: 16 + 6)
@@ -294,7 +294,7 @@ private struct BalloonsPreviewView: View {
                     Button {
                         isPresenting.toggle()
                     } label: {
-                        Image(charocalIcon: .question24)
+                        Image(charcoalIcon: .question24)
                     }
                     .charcoalBalloon(
                         isPresenting: $isPresenting,
@@ -328,7 +328,7 @@ private struct BalloonsPreviewView: View {
                     Button {
                         isPresenting4.toggle()
                     } label: {
-                        Image(charocalIcon: .question24)
+                        Image(charcoalIcon: .question24)
                     }
                     .charcoalBalloon(isPresenting: $isPresenting4, text: "Hello World This is a tooltip and here is testing it's multiple line feature")
                     .offset(CGSize(width: geometry.size.width - 30, height: geometry.size.height - 40))
@@ -349,7 +349,7 @@ private struct BalloonsPreviewView: View {
                     Button {
                         isPresenting6.toggle()
                     } label: {
-                        Image(charocalIcon: .question24)
+                        Image(charcoalIcon: .question24)
                     }
                     .charcoalBalloon(isPresenting: $isPresenting6, text: "Hello World This is a tooltip and here is testing it's multiple line feature")
                     .offset(CGSize(width: geometry.size.width - 380, height: geometry.size.height - 240))

--- a/Sources/CharcoalSwiftUI/Components/Hint/CharcoalHint.swift
+++ b/Sources/CharcoalSwiftUI/Components/Hint/CharcoalHint.swift
@@ -38,7 +38,7 @@ public struct CharcoalHint: View {
     public var body: some View {
         if isPresenting {
             HStack(spacing: 4) {
-                Image(charocalIcon: icon)
+                Image(charcoalIcon: icon)
 
                 VStack {
                     Text(text).charcoalTypography14Regular()

--- a/Sources/CharcoalSwiftUI/Components/Toast/CharcoalToast.swift
+++ b/Sources/CharcoalSwiftUI/Components/Toast/CharcoalToast.swift
@@ -240,7 +240,7 @@ public extension View {
                 Button {
                     isPresenting = false
                 } label: {
-                    Image(charocalIcon: .remove16)
+                    Image(charcoalIcon: .remove16)
                         .renderingMode(.template)
                 }
             }
@@ -255,7 +255,7 @@ public extension View {
                 Button {
                     isPresenting2 = false
                 } label: {
-                    Image(charocalIcon: .remove16)
+                    Image(charcoalIcon: .remove16)
                         .renderingMode(.template)
                 }
             }

--- a/Sources/CharcoalSwiftUI/Components/Tooltip/CharcoalTooltip.swift
+++ b/Sources/CharcoalSwiftUI/Components/Tooltip/CharcoalTooltip.swift
@@ -243,7 +243,7 @@ public extension View {
                 Button {
                     isPresenting.toggle()
                 } label: {
-                    Image(charocalIcon: .question24)
+                    Image(charcoalIcon: .question24)
                 }
                 .charcoalTooltip(isPresenting: $isPresenting, text: "Hello World")
                 .offset(CGSize(width: 20.0, height: 80.0))
@@ -269,7 +269,7 @@ public extension View {
                 Button {
                     isPresenting4.toggle()
                 } label: {
-                    Image(charocalIcon: .question24)
+                    Image(charcoalIcon: .question24)
                 }
                 .charcoalTooltip(isPresenting: $isPresenting4, text: "Hello World This is a tooltip and here is testing it's multiple line feature")
                 .offset(CGSize(width: proxy.size.width - 30, height: proxy.size.height - 40))
@@ -290,7 +290,7 @@ public extension View {
                 Button {
                     isPresenting6.toggle()
                 } label: {
-                    Image(charocalIcon: .question24)
+                    Image(charcoalIcon: .question24)
                 }
                 .charcoalTooltip(isPresenting: $isPresenting6, text: "Hello World This is a tooltip and here is testing it's multiple line feature")
                 .offset(CGSize(width: proxy.size.width - 380, height: proxy.size.height - 240))

--- a/Sources/CharcoalSwiftUI/Images/Image.swift
+++ b/Sources/CharcoalSwiftUI/Images/Image.swift
@@ -1,16 +1,16 @@
 import SwiftUI
 
 public extension Image {
-    @inlinable init(charocalIcon: CharcoalAsset.Images) {
-        self.init(asset: charocalIcon.imageAsset)
+    @inlinable init(charcoalIcon: CharcoalAsset.Images) {
+        self.init(asset: charcoalIcon.imageAsset)
     }
 }
 
 #Preview {
     VStack {
-        Image(charocalIcon: .add24)
-        Image(charocalIcon: .delete32)
-        Image(charocalIcon: .addInline)
-        Image(charocalIcon: .codes24)
+        Image(charcoalIcon: .add24)
+        Image(charcoalIcon: .delete32)
+        Image(charcoalIcon: .addInline)
+        Image(charcoalIcon: .codes24)
     }
 }


### PR DESCRIPTION
## 解決したいこと
- `Image(charocalIcon:)` が `charcoalIcon` をtypoしている事に気付いたため、正しい形に修正します

## やったこと
- `Image(charocalIcon:)` -> `Image(charcoalIcon:)` に置き換えました
- README内にもtypoがあったので修正しました `CharocalUIKit` -> `CharcoalUIKit`

## やらないこと

## スクリーンショット

## 動作確認環境