### PR TITLE
Text結合による装飾テキストを扱えるように、TextのままfontとforegroundStyleが適用できるようにしました

### DIFF
--- a/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/TypographiesView.swift
+++ b/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/TypographiesView.swift
@@ -42,6 +42,15 @@ struct TypographiesView: View {
                         Text(Const.numberText)
                             .charcoalTypography20RegularMono()
                     }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("20 Attributed String")
+
+                        Text("Atributed")
+                            .font(charcoalTypography: .bold20)
+                        +
+                        Text("String")
+                            .font(charcoalTypography: .regular20)
+                    }
                 }
                 Group {
                     VStack(alignment: .leading, spacing: 4) {
@@ -73,6 +82,15 @@ struct TypographiesView: View {
                         Text("16 Regular Mono")
                         Text(Const.numberText)
                             .charcoalTypography16RegularMono()
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("16 Attributed String")
+
+                        Text("Atributed")
+                            .font(charcoalTypography: .bold16)
+                        +
+                        Text("String")
+                            .font(charcoalTypography: .regular16)
                     }
                 }
                 Group {
@@ -106,6 +124,15 @@ struct TypographiesView: View {
                         Text(Const.numberText)
                             .charcoalTypography14RegularMono()
                     }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("14 Attributed String")
+
+                        Text("Atributed")
+                            .font(charcoalTypography: .bold14)
+                        +
+                        Text("String")
+                            .font(charcoalTypography: .regular14)
+                    }
                 }
                 Group {
                     VStack(alignment: .leading, spacing: 4) {
@@ -138,6 +165,15 @@ struct TypographiesView: View {
                         Text(Const.numberText)
                             .charcoalTypography12RegularMono()
                     }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("12 Attributed String")
+
+                        Text("Atributed")
+                            .font(charcoalTypography: .bold12)
+                        +
+                        Text("String")
+                            .font(charcoalTypography: .regular12)
+                    }
                 }
                 Group {
                     VStack(alignment: .leading, spacing: 4) {
@@ -169,6 +205,15 @@ struct TypographiesView: View {
                         Text("10 Regular Mono")
                         Text(Const.numberText)
                             .charcoalTypography10RegularMono()
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("10 Attributed String")
+
+                        Text("Atributed")
+                            .font(charcoalTypography: .bold10)
+                        +
+                        Text("String")
+                            .font(charcoalTypography: .regular10)
                     }
                 }
             }

--- a/Sources/CharcoalSwiftUI/Backport/View/ForegroundStyle.swift
+++ b/Sources/CharcoalSwiftUI/Backport/View/ForegroundStyle.swift
@@ -11,3 +11,15 @@ extension Backport where Content: View {
         }
     }
 }
+
+extension Backport where Content == Text {
+    func foregroundStyle(_ color: Color) -> Text {
+        if #available(iOS 17, *) {
+            content
+                .foregroundStyle(color)
+        } else {
+            content
+                .foregroundColor(color)
+        }
+    }
+}

--- a/Sources/CharcoalSwiftUI/Colors/Foregrounds.swift
+++ b/Sources/CharcoalSwiftUI/Colors/Foregrounds.swift
@@ -14,9 +14,21 @@ public extension View {
     }
 }
 
+public extension Text {
+    func foregroundStyle(charcoalColor: CharcoalAsset.ColorPaletteGenerated) -> Text {
+        self.backport.foregroundStyle(charcoalColor.colorAsset.swiftUIColor)
+    }
+}
+
 #Preview {
-    ZStack {
+    VStack {
         Text("Charcoal")
             .foregroundStyle(charcoalColor: .brand)
+
+        Text("Attributed")
+            .foregroundStyle(charcoalColor: .brand)
+        +
+        Text("String")
+            .foregroundStyle(charcoalColor: .text3)
     }
 }

--- a/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypography.swift
+++ b/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypography.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+public extension Text {
+    enum CharcoalTypography {
+        case regular10
+        case bold10
+        case regular12
+        case bold12
+        case regular14
+        case bold14
+        case regular16
+        case bold16
+        case regular20
+        case bold20
+
+        typealias Value = (size: CGFloat, weight: UIFont.Weight)
+
+        var value: Value {
+            switch self {
+            case .regular10:
+                return (size: 10, weight: .regular)
+            case .bold10:
+                return (size: 10, weight: .bold)
+            case .regular12:
+                return (size: CGFloat(charcoalFoundation.typography.size.the12.fontSize), weight: .regular)
+            case .bold12:
+                return (size: CGFloat(charcoalFoundation.typography.size.the12.fontSize), weight: .bold)
+            case .regular14:
+                return (size: CGFloat(charcoalFoundation.typography.size.the14.fontSize), weight: .regular)
+            case .bold14:
+                return (size: CGFloat(charcoalFoundation.typography.size.the14.fontSize), weight: .bold)
+            case .regular16:
+                return (size: CGFloat(charcoalFoundation.typography.size.the16.fontSize), weight: .regular)
+            case .bold16:
+                return (size: CGFloat(charcoalFoundation.typography.size.the16.fontSize), weight: .bold)
+            case .regular20:
+                return (size: CGFloat(charcoalFoundation.typography.size.the20.fontSize), weight: .regular)
+            case .bold20:
+                return (size: CGFloat(charcoalFoundation.typography.size.the20.fontSize), weight: .bold)
+            }
+        }
+    }
+
+    func font(charcoalTypography: CharcoalTypography) -> Text {
+        self
+            .font(
+                .custom(UIFont.monospacedSystemFont(ofSize: .zero, weight: charcoalTypography.value.weight).fontName,
+                          size: charcoalTypography.value.size,
+                          relativeTo: .body)
+            )
+    }
+}


### PR DESCRIPTION
## 解決したいこと
- 下のようなText結合による装飾テキストを扱いたいです

<img width="198" alt="スクリーンショット 2024-10-26 2 19 13" src="https://github.com/user-attachments/assets/86b991d2-e39a-493e-99b4-d11cc1d7b0fa">


```swift
Text(Image(systemName: "heart.fill"))
    .font(.title)
    .foregroundStyle(.pink)
+
Text("Attributed Text")
    .font(.title)
    .bold()
    .foregroundStyle(.blue)
+
Text("small")
    .font(.caption)
    .foregroundStyle(.red)
+
Text("Strike")
    .strikethrough()
```

既存の `.charcoalTypography` `.charcoalOnSurface` ModifierだとViewへ変換されてしまい、上のようなテキスト結合による装飾が実現できないため、Text型のままtypographyとstyleを適用できるようにしたいです。

## やったこと
- Textに `.font(charcoalTypography:)` と `.foregroundStyle(charcoalColor:)` を足しました

## スクリーンショット
<img width="786" alt="スクリーンショット 2024-10-26 2 34 00" src="https://github.com/user-attachments/assets/8a18d478-8be4-4e69-9330-a9aa4f6a78b3">

## 動作確認環境
- iPhone SE 16.4
- iPhone 16 Pro 18.0