### PR TITLE
アイコンがベクターとして扱えなかった問題を修正

### DIFF
--- a/scripts/xcasset-gen/src/XcassetGenerator.js
+++ b/scripts/xcasset-gen/src/XcassetGenerator.js
@@ -59,7 +59,8 @@ function createUniversalImageJson(filename) {
                 'filename': filename
             }
         ],
-        ...createXCAssetInfoJSON()
+        ...createXCAssetInfoJSON(),
+        ...createPreservesVectorRepresentationJSON()
     }
 }
 
@@ -77,6 +78,14 @@ function createXCAssetInfoJSON() {
         'info': {
             'version': 1,
             'author': 'pixiv'
+        }
+    }
+}
+
+function createPreservesVectorRepresentationJSON() {
+    return {
+        'properties': {
+            "preserves-vector-representation" : true
         }
     }
 }


### PR DESCRIPTION
## 解決したいこと
- アイコンがベクターとして利用できなかったこと
  - Xcodeを利用してcharcoal-iosに存在するアセットを開いたときに、それぞれのアセットが`preserves-vector-representation`に対応していなかったのが原因である

## やったこと
- XcassetGenerator.js に対して`preserves-vector-representation`の`properties`を追加するように修正

## やらないこと
- なし

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- Apple Swift version 6.0.3 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)
