### PR TITLE
Feat button hover

### DIFF
--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalButtonSizes+Extension.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalButtonSizes+Extension.swift
@@ -10,10 +10,6 @@ extension CharcoalButtonSize {
         }
     }
 
-    var cornerRadius: CGFloat {
-        return padding.leading
-    }
-
     var fontSize: CGFloat {
         return 14
     }

--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalDefaultButton.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalDefaultButton.swift
@@ -9,8 +9,6 @@ struct CharcoalDefaultButtonStyleView: View {
 
     @ScaledMetric var fontSize: CGFloat
 
-    @ScaledMetric var cornerRadius: CGFloat
-
     init(label: ButtonStyleConfiguration.Label, isPressed: Bool, isEnabled: Bool, size: CharcoalButtonSize, isFixed: Bool) {
         self.label = label
         self.isPressed = isPressed
@@ -18,7 +16,6 @@ struct CharcoalDefaultButtonStyleView: View {
         self.size = size
         self.isFixed = isFixed
         _fontSize = ScaledMetric(wrappedValue: size.fontSize)
-        _cornerRadius = ScaledMetric(wrappedValue: size.cornerRadius)
     }
 
     var body: some View {
@@ -33,7 +30,8 @@ struct CharcoalDefaultButtonStyleView: View {
                 Rectangle()
                     .backport.foregroundStyle(isPressed ? Color(CharcoalAsset.ColorPaletteGenerated.surface10.color) : .clear)
             )
-            .cornerRadius(cornerRadius)
+            .clipShape(.capsule)
+            .hoverEffect(.lift)
     }
 }
 

--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalDefaultOverlay.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalDefaultOverlay.swift
@@ -9,8 +9,6 @@ struct CharcoalDefaultOverlayButtonStyleView: View {
 
     @ScaledMetric var fontSize: CGFloat
 
-    @ScaledMetric var cornerRadius: CGFloat
-
     init(label: ButtonStyleConfiguration.Label, isPressed: Bool, isEnabled: Bool, size: CharcoalButtonSize, isFixed: Bool) {
         self.label = label
         self.isPressed = isPressed
@@ -18,7 +16,6 @@ struct CharcoalDefaultOverlayButtonStyleView: View {
         self.size = size
         self.isFixed = isFixed
         _fontSize = ScaledMetric(wrappedValue: size.fontSize)
-        _cornerRadius = ScaledMetric(wrappedValue: size.cornerRadius)
     }
 
     var body: some View {
@@ -33,7 +30,8 @@ struct CharcoalDefaultOverlayButtonStyleView: View {
                 Rectangle()
                     .backport.foregroundStyle(isPressed ? Color(CharcoalAsset.ColorPaletteGenerated.surface10.color) : .clear)
             )
-            .cornerRadius(cornerRadius)
+            .clipShape(.capsule)
+            .hoverEffect(.lift)
     }
 }
 

--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalLinkButton.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalLinkButton.swift
@@ -11,9 +11,10 @@ struct CharcoalLinkButtonStyleView: View {
         label
             .font(.system(size: fontSize, weight: .bold))
             // swiftlint:disable line_length
-            .padding(EdgeInsets(top: 11.5, leading: 0, bottom: 11.5, trailing: 0))
+            .padding(EdgeInsets(top: 11.5, leading: 16, bottom: 11.5, trailing: 16))
             .foregroundStyle(charcoalColor: isPressed ? .text3 : .text1)
             .opacity(isEnabled ? 1.0 : 0.32)
+            .hoverEffect(.highlight)
     }
 }
 

--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalNavigationButton.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalNavigationButton.swift
@@ -9,8 +9,6 @@ struct CharcoalNavigationButtonStyleView: View {
 
     @ScaledMetric var fontSize: CGFloat
 
-    @ScaledMetric var cornerRadius: CGFloat
-
     init(label: ButtonStyleConfiguration.Label, isPressed: Bool, isEnabled: Bool, size: CharcoalButtonSize, isFixed: Bool) {
         self.label = label
         self.isPressed = isPressed
@@ -18,7 +16,6 @@ struct CharcoalNavigationButtonStyleView: View {
         self.size = size
         self.isFixed = isFixed
         _fontSize = ScaledMetric(wrappedValue: size.fontSize)
-        _cornerRadius = ScaledMetric(wrappedValue: size.cornerRadius)
     }
 
     var body: some View {
@@ -38,7 +35,8 @@ struct CharcoalNavigationButtonStyleView: View {
                 Rectangle()
                     .backport.foregroundStyle(isPressed ? Color(CharcoalAsset.ColorPaletteGenerated.surface10.color) : .clear)
             )
-            .cornerRadius(cornerRadius)
+            .clipShape(.capsule)
+            .hoverEffect(.lift)
         )
     }
 }

--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalPrimaryButton.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalPrimaryButton.swift
@@ -10,8 +10,6 @@ struct CharcoalPrimaryButtonStyleView: View {
 
     @ScaledMetric var fontSize: CGFloat
 
-    @ScaledMetric var cornerRadius: CGFloat
-
     init(label: ButtonStyleConfiguration.Label, isPressed: Bool, isEnabled: Bool, size: CharcoalButtonSize, isFixed: Bool, primaryColor: Color) {
         self.label = label
         self.isPressed = isPressed
@@ -20,7 +18,6 @@ struct CharcoalPrimaryButtonStyleView: View {
         self.isFixed = isFixed
         self.primaryColor = primaryColor
         _fontSize = ScaledMetric(wrappedValue: size.fontSize)
-        _cornerRadius = ScaledMetric(wrappedValue: size.cornerRadius)
     }
 
     var body: some View {
@@ -35,7 +32,8 @@ struct CharcoalPrimaryButtonStyleView: View {
                 Rectangle()
                     .backport.foregroundStyle(isPressed ? Color(CharcoalAsset.ColorPaletteGenerated.surface10.color) : .clear)
             )
-            .cornerRadius(cornerRadius)
+            .clipShape(.capsule)
+            .hoverEffect(.lift)
     }
 }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalDefaultMButton.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalDefaultMButton.swift
@@ -57,6 +57,8 @@ public class CharcoalDefaultMButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalDefaultOverlayMButton.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalDefaultOverlayMButton.swift
@@ -57,6 +57,8 @@ public class CharcoalDefaultOverlayMButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalDefaultOverlaySButton.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalDefaultOverlaySButton.swift
@@ -57,6 +57,8 @@ public class CharcoalDefaultOverlaySButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalDefaultSButton.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalDefaultSButton.swift
@@ -57,6 +57,8 @@ public class CharcoalDefaultSButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalLinkButton_UIKit.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalLinkButton_UIKit.swift
@@ -55,6 +55,8 @@ public class CharcoalLinkButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalNavigationButton_UIKit.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalNavigationButton_UIKit.swift
@@ -57,6 +57,8 @@ public class CharcoalNavigationMButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalNavigationSButton.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalNavigationSButton.swift
@@ -57,6 +57,8 @@ public class CharcoalNavigationSButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalPrimaryMButton.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalPrimaryMButton.swift
@@ -62,6 +62,8 @@ public class CharcoalPrimaryMButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 

--- a/Sources/CharcoalUIKit/Components/Buttons/CharcoalPrimarySButton.swift
+++ b/Sources/CharcoalUIKit/Components/Buttons/CharcoalPrimarySButton.swift
@@ -58,6 +58,8 @@ public class CharcoalPrimarySButton: UIButton, CharcoalButton {
             )
         }
 
+        isPointerInteractionEnabled = true
+
         updateStyle()
     }
 


### PR DESCRIPTION
## 解決したいこと
- Apple PencilやTrackpadに接続している際にホバーエフェクトが表示されたい

## やったこと
- UIKit
  - ButtonsにisPointerInteractionEnabledを追加
- SwiftUI
  - UIKitの実装と合うように以下の指定を追加
  - capsule型のアイコンには.hoverEffect(.lift)を設定
    - cornerRadiusではなくclipShapeを使った実装にして、エフェクトがcapsule型になるように
  - LinkButtonは.hoverEffect(.highlight)を設定

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
