### PR TITLE
CharcoalModalにクローズボタンを付与

### DIFF
--- a/Sources/CharcoalSwiftUI/Modal/CharcoalModalView.swift
+++ b/Sources/CharcoalSwiftUI/Modal/CharcoalModalView.swift
@@ -131,7 +131,7 @@ struct CharcoalModalView<ModalContent: View, ActionContent: View>: View {
     }
 
     private func contentView(proxy: GeometryProxy) -> some View {
-        ZStack {
+        ZStack(alignment: .topTrailing) {
             VStack(spacing: 0) {
                 if let title = title {
                     Text(title).charcoalTypography20Bold(isSingleLine: true)
@@ -157,7 +157,6 @@ struct CharcoalModalView<ModalContent: View, ActionContent: View>: View {
                 Image(charcoalIcon: .close24)
             }
             .padding(.all, 12)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
         }
     }
 }

--- a/Sources/CharcoalSwiftUI/Modal/CharcoalModalView.swift
+++ b/Sources/CharcoalSwiftUI/Modal/CharcoalModalView.swift
@@ -87,36 +87,19 @@ struct CharcoalModalView<ModalContent: View, ActionContent: View>: View {
                     }
 
                 // Modal Content
-                VStack(spacing: 0) {
-                    if let title = title {
-                        Text(title).charcoalTypography20Bold(isSingleLine: true)
-                            .padding(EdgeInsets(top: 20, leading: 0, bottom: 20, trailing: 0))
-                    }
-
-                    modalContent
-
-                    if let actions = actions {
-                        VStack {
-                            actions
-                        }
-                        .padding(EdgeInsets(top: 20, leading: 20, bottom: style == .center ? 20 : indicatorInset, trailing: 20))
-                        .onAppear {
-                            indicatorInset = max(proxy.safeAreaInsets.bottom, 30)
-                        }
-                    }
-                }
-                .frame(minWidth: 280, maxWidth: maxWidth)
-                .background(Rectangle().cornerRadius(32, corners: style.roundedCorners).foregroundStyle(charcoalColor: .surface1))
-                .opacity(modalOpacity)
-                .padding(style.padding)
-                .offset(modalOffset)
-                .animation(modalOffsetAnimation, value: modalOffset)
-                .animation(.easeInOut(duration: duration), value: modalOpacity)
-                .scaleEffect(modalScale)
-                .animation(UIAccessibility.isReduceMotionEnabled ? .none : .easeInOut(duration: duration * 0.5), value: modalScale)
-                .overlay(GeometryReader { modalGeomtry in
-                    Color.clear.preference(key: ModalViewHeightKey.self, value: modalGeomtry.size.height)
-                })
+                contentView(proxy: proxy)
+                    .frame(minWidth: 280, maxWidth: maxWidth)
+                    .background(Rectangle().cornerRadius(32, corners: style.roundedCorners).foregroundStyle(charcoalColor: .surface1))
+                    .opacity(modalOpacity)
+                    .padding(style.padding)
+                    .offset(modalOffset)
+                    .animation(modalOffsetAnimation, value: modalOffset)
+                    .animation(.easeInOut(duration: duration), value: modalOpacity)
+                    .scaleEffect(modalScale)
+                    .animation(UIAccessibility.isReduceMotionEnabled ? .none : .easeInOut(duration: duration * 0.5), value: modalScale)
+                    .overlay(GeometryReader { modalGeomtry in
+                        Color.clear.preference(key: ModalViewHeightKey.self, value: modalGeomtry.size.height)
+                    })
             })
             .onPreferenceChange(ModalViewHeightKey.self, perform: { value in
                 let offset = CGSize(width: 0, height: value)
@@ -144,6 +127,37 @@ struct CharcoalModalView<ModalContent: View, ActionContent: View>: View {
             DispatchQueue.main.async {
                 prepareAnimation()
             }
+        }
+    }
+
+    private func contentView(proxy: GeometryProxy) -> some View {
+        ZStack {
+            VStack(spacing: 0) {
+                if let title = title {
+                    Text(title).charcoalTypography20Bold(isSingleLine: true)
+                        .padding(EdgeInsets(top: 20, leading: 0, bottom: 20, trailing: 0))
+                }
+
+                modalContent
+
+                if let actions = actions {
+                    VStack {
+                        actions
+                    }
+                    .padding(EdgeInsets(top: 20, leading: 20, bottom: style == .center ? 20 : indicatorInset, trailing: 20))
+                    .onAppear {
+                        indicatorInset = max(proxy.safeAreaInsets.bottom, 30)
+                    }
+                }
+            }
+
+            Button {
+                isPresented = false
+            } label: {
+                Image(charcoalIcon: .close24)
+            }
+            .padding(.all, 12)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
         }
     }
 }

--- a/Sources/CharcoalSwiftUI/Modal/CharcoalModalView.swift
+++ b/Sources/CharcoalSwiftUI/Modal/CharcoalModalView.swift
@@ -259,17 +259,13 @@ public extension View {
                     }).charcoalDefaultButton(size: .medium)
                 }
             ) {
-                NavigationView {
-                    VStack(spacing: 10) {
-                        Text("Hello This is a center dialog from Charcoal")
-                            .charcoalTypography16Regular()
-                            .frame(maxWidth: .infinity)
+                VStack(spacing: 10) {
+                    Text("Hello This is a center dialog from Charcoal")
+                        .charcoalTypography16Regular()
+                        .frame(maxWidth: .infinity)
 
-                        TextField("Simple text field", text: $text1).charcoalTextField()
-                    }.padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
-                        .navigationTitle("SwiftUI")
-                        .navigationBarTitleDisplayMode(.inline)
-                }
+                    TextField("Simple text field", text: $text1).charcoalTextField()
+                }.padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
             }
         }
     }


### PR DESCRIPTION
## 解決したいこと
- [ドキュメント](https://pixiv.github.io/charcoal-ios/documentation/charcoal/)を見るに、CharcoalModalには本来右上にxボタンが存在するのが正しい仕様っぽそうだったので、CharcoalModalにクローズボタンを付与

## やったこと

- CharcoalModalViewにクローズボタンを実装
- クローズボタンをタップするとモーダルがdismissするように実装
- Previewから不要なNavigationViewを削除

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---
<img width="314" alt="スクリーンショット 2025-04-24 18 39 45" src="https://github.com/user-attachments/assets/81274f26-8ce8-4097-9555-6112f2e951a8" />|<img width="311" alt="スクリーンショット 2025-04-24 18 37 06" src="https://github.com/user-attachments/assets/ff73318e-a0d0-471d-b504-9523e32f2d78" />


## 動作確認環境
- Xcode 16.2
