### PR TITLE
UIKitでCharcoalModalを使えるCharcoalModalControllerを作成

### DIFF
--- a/Sources/CharcoalUIKit/Components/Modal/CharcoalModalActionsView.swift
+++ b/Sources/CharcoalUIKit/Components/Modal/CharcoalModalActionsView.swift
@@ -1,0 +1,144 @@
+import CharcoalShared
+import UIKit
+
+public struct CharcoalModalAction: Sendable {
+    public enum Style: Sendable {
+        public typealias Handler = @MainActor @Sendable () -> Void
+
+        case primary(_ handler: Handler)
+        case normal(_ handler: Handler)
+        case destractive(_ handler: Handler)
+        case cancel
+    }
+
+    let title: String
+    let style: Style
+
+    public init(title: String, style: Style) {
+        self.title = title
+        self.style = style
+    }
+}
+
+final class CharcoalModalActionsView: UIView {
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        stackView.alignment = .fill
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        return stackView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    var dismiss: (() -> Void)?
+
+    func addAction(_ action: CharcoalModalAction) {
+        let button: CharcoalButton
+
+        switch action.style {
+        case let .primary(handler):
+            button = CharcoalPrimaryMButton()
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.setTitle(action.title, for: .normal)
+            button.addAction(
+                .init { _ in handler() },
+                for: .touchUpInside
+            )
+
+        case let .normal(handler):
+            button = CharcoalDefaultMButton()
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.setTitle(action.title, for: .normal)
+            button.addAction(
+                .init { _ in handler() },
+                for: .touchUpInside
+            )
+
+        case .cancel:
+            button = CharcoalDefaultMButton()
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.setTitle(action.title, for: .normal)
+            button.addAction(
+                .init { [weak self] _ in self?.dismiss?() },
+                for: .touchUpInside
+            )
+
+        case let .destractive(handler):
+            let primaryButton = CharcoalPrimaryMButton()
+            primaryButton.primaryColor = CharcoalAsset.ColorPaletteGenerated.assertive.color
+
+            button = primaryButton
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.setTitle(action.title, for: .normal)
+            button.addAction(
+                .init { _ in handler() },
+                for: .touchUpInside
+            )
+        }
+
+        stackView.addArrangedSubview(button)
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let buttonHeights = stackView.subviews.map(\.intrinsicContentSize.height)
+
+        let totalButtonHeight: CGFloat = buttonHeights.reduce(0, +)
+        let totalSpacing: CGFloat = 8 * CGFloat(buttonHeights.count - 1)
+        let totalPadding: CGFloat = 40
+
+        return CGSize(
+            width: size.width,
+            height: totalButtonHeight + totalSpacing + totalPadding
+        )
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    let actionsView = CharcoalModalActionsView()
+    actionsView.addAction(.init(
+        title: "Primary Action",
+        style: .primary({})
+    ))
+    actionsView.addAction(.init(
+        title: "Normal Action",
+        style: .normal({})
+    ))
+    actionsView.addAction(.init(
+        title: "Cancel Action",
+        style: .cancel
+    ))
+    actionsView.addAction(.init(
+        title: "Destractive Action",
+        style: .destractive({})
+    ))
+
+    actionsView.backgroundColor = CharcoalAsset.ColorPaletteGenerated.surface3.color
+    actionsView.clipsToBounds = true
+    actionsView.layer.cornerRadius = 32
+    actionsView.layer.maskedCorners = [
+        .layerMinXMaxYCorner,
+        .layerMaxXMaxYCorner,
+    ]
+
+    return actionsView
+}

--- a/Sources/CharcoalUIKit/Components/Modal/CharcoalModalContentView.swift
+++ b/Sources/CharcoalUIKit/Components/Modal/CharcoalModalContentView.swift
@@ -1,0 +1,73 @@
+import CharcoalShared
+import UIKit
+
+final class CharcoalModalContentView: UIView {
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        stackView.alignment = .fill
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        return stackView
+    }()
+
+    init(message: String?, content: UIView?) {
+        super.init(frame: .null)
+
+        if let message {
+            let messageLabel = CharcoalTypography16()
+            messageLabel.translatesAutoresizingMaskIntoConstraints = false
+            messageLabel.text = message
+            messageLabel.textAlignment = .center
+            messageLabel.numberOfLines = 0
+
+            stackView.addArrangedSubview(messageLabel)
+        }
+
+        if let content {
+            content.translatesAutoresizingMaskIntoConstraints = false
+            stackView.addArrangedSubview(content)
+        }
+
+        addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let subViewHeights = stackView.subviews.map({ $0.sizeThatFits(size).height })
+
+        let totalButtonHeight: CGFloat = subViewHeights.reduce(0, +)
+        let totalSpacing: CGFloat = 8 * CGFloat(subViewHeights.count - 1)
+        let totalPadding: CGFloat = 40
+
+        return CGSize(
+            width: size.width,
+            height: totalButtonHeight + totalSpacing + totalPadding
+        )
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    let contentView = CharcoalModalContentView(
+        message: "MessageMessageMessageMessageMessageMessageMessage",
+        content: SpinnerContainerView(
+            subview: CharcoalSpinnerView(spinnerSize: 48)
+        )
+    )
+    contentView.backgroundColor = CharcoalAsset.ColorPaletteGenerated.surface3.color
+
+    return contentView
+}

--- a/Sources/CharcoalUIKit/Components/Modal/CharcoalModalController.swift
+++ b/Sources/CharcoalUIKit/Components/Modal/CharcoalModalController.swift
@@ -1,0 +1,134 @@
+import CharcoalShared
+import UIKit
+
+@available(iOS 15, *)
+public final class CharcoalModalController: UIViewController {
+    let titleText: String?
+    let message: String?
+    let content: UIView?
+
+    public var tapBackgroundToDismiss: Bool = true
+
+    public init(title: String?, message: String?, content: UIView?) {
+        titleText = title
+        self.message = message
+        self.content = content
+        super.init(nibName: nil, bundle: nil)
+
+        modalTransitionStyle = .crossDissolve
+        modalPresentationStyle = .overFullScreen
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private let actionsView = CharcoalModalActionsView()
+
+    public func addAction(_ action: CharcoalModalAction) {
+        actionsView.addAction(action)
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = UIColor(white: 0, alpha: 0.6)
+        view.isUserInteractionEnabled = true
+
+        let modalBackgroundView = UIView()
+        modalBackgroundView.translatesAutoresizingMaskIntoConstraints = false
+        modalBackgroundView.backgroundColor = CharcoalAsset.ColorPaletteGenerated.surface1.color
+        modalBackgroundView.clipsToBounds = true
+        modalBackgroundView.layer.cornerRadius = 32
+
+        let header = CharcoalModalHeader(
+            title: titleText,
+            closeButtonTapped: { [weak self] in
+                self?.dismiss(animated: true)
+            }
+        )
+        header.translatesAutoresizingMaskIntoConstraints = false
+
+        let contentView = CharcoalModalContentView(
+            message: message,
+            content: content
+        )
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+
+        actionsView.translatesAutoresizingMaskIntoConstraints = false
+        actionsView.dismiss = { [weak self] in self?.dismiss(animated: true) }
+
+        view.addSubview(modalBackgroundView)
+        modalBackgroundView.addSubview(header)
+        modalBackgroundView.addSubview(contentView)
+        modalBackgroundView.addSubview(actionsView)
+
+        NSLayoutConstraint.activate([
+            modalBackgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            modalBackgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            modalBackgroundView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            header.topAnchor.constraint(equalTo: modalBackgroundView.topAnchor),
+            header.leadingAnchor.constraint(equalTo: modalBackgroundView.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: modalBackgroundView.trailingAnchor),
+
+            contentView.topAnchor.constraint(equalTo: header.bottomAnchor),
+            contentView.leadingAnchor.constraint(equalTo: modalBackgroundView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: modalBackgroundView.trailingAnchor),
+
+            actionsView.topAnchor.constraint(equalTo: contentView.bottomAnchor),
+            actionsView.leadingAnchor.constraint(equalTo: modalBackgroundView.leadingAnchor),
+            actionsView.trailingAnchor.constraint(equalTo: modalBackgroundView.trailingAnchor),
+            actionsView.bottomAnchor.constraint(equalTo: modalBackgroundView.bottomAnchor),
+        ])
+    }
+}
+
+#if DEBUG
+@available(iOS 15, *)
+private final class RootViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = "Show"
+        let button = UIButton(configuration: configuration)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Show", for: .normal)
+        button.addAction(
+            .init { [weak self] _ in
+                let charcoalModalController = CharcoalModalController(
+                    title: "Title",
+                    message: "message",
+                    content: nil
+                )
+                charcoalModalController.addAction(.init(
+                    title: "Primary Action",
+                    style: .primary({
+                        print("Primary action tapped")
+                    })
+                ))
+                charcoalModalController.addAction(.init(
+                    title: "Cancel",
+                    style: .cancel
+                ))
+
+                self?.present(charcoalModalController, animated: true)
+            },
+            for: .touchUpInside
+        )
+
+        view.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            button.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+    }
+}
+#endif
+
+@available(iOS 17, *)
+#Preview {
+    RootViewController()
+}

--- a/Sources/CharcoalUIKit/Components/Modal/CharcoalModalHeader.swift
+++ b/Sources/CharcoalUIKit/Components/Modal/CharcoalModalHeader.swift
@@ -1,0 +1,70 @@
+import CharcoalShared
+import UIKit
+
+@available(iOS 15, *)
+final class CharcoalModalHeader: UIView {
+    init(title: String?, closeButtonTapped: @escaping @Sendable () -> Void) {
+        super.init(frame: .null)
+
+        let titleLabel = CharcoalTypography20()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.isBold = true
+        titleLabel.text = title
+
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = CharcoalAsset.Images.close24.image
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+        let closeButton = UIButton(configuration: configuration)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.addAction(
+            .init { _ in closeButtonTapped() },
+            for: .touchUpInside
+        )
+
+        addSubview(titleLabel)
+        addSubview(closeButton)
+
+        NSLayoutConstraint.activate([
+            titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            closeButton.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            closeButton.rightAnchor.constraint(equalTo: rightAnchor, constant: -8),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        CGSize(
+            width: size.width,
+            height: min(64, size.height)
+        )
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(
+            width: UIScreen.main.bounds.width - 48,
+            height: 64
+        )
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    let header = CharcoalModalHeader(
+        title: "Title",
+        closeButtonTapped: { print("Close button tapped") }
+    )
+    header.backgroundColor = CharcoalAsset.ColorPaletteGenerated.surface3.color
+    header.clipsToBounds = true
+    header.layer.cornerRadius = 32
+    header.layer.maskedCorners = [
+        .layerMinXMinYCorner,
+        .layerMaxXMinYCorner,
+    ]
+
+    return header
+}


### PR DESCRIPTION
## 解決したいこと
- UIKitでCharcoalModalを使いたい

## やったこと
- CharcoalModalControllerを作成

## まだやっていないこと
- CharcoalModalControllerのドキュメンテーション

## やらないこと
- Modal表示時のアニメーションをCharcoalModalViewに揃える

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください
<img width="274" alt="スクリーンショット 2025-04-25 0 54 23" src="https://github.com/user-attachments/assets/82f52652-aea6-4010-829e-d712c7ebd8a1" />


## 動作確認環境
- Xcode 16.2
