### PR TITLE
numberOfLines>=2の時にlineSpacingが設定されない問題を修正

### DIFF
--- a/Sources/CharcoalSwiftUI/Components/Typographies/FontModifiers.swift
+++ b/Sources/CharcoalSwiftUI/Components/Typographies/FontModifiers.swift
@@ -22,7 +22,7 @@ struct CharcoalFontModifier: ViewModifier {
         let font: UIFont = .systemFont(ofSize: fontSize, weight: weight)
         return content
             .font(Font(font))
-            .lineSpacing(isSingleLine ? 0 : lineHeight - font.lineHeight)
+            .lineSpacing(lineHeight - font.lineHeight)
             .padding(.vertical, isSingleLine ? 0 : (lineHeight - font.lineHeight) / 2)
             .lineLimit(isSingleLine ? 1 : nil)
             .fixedSize(horizontal: false, vertical: true)

--- a/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
+++ b/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
@@ -18,7 +18,7 @@ extension UILabel {
     }
 
     func setupLineHeight(lineHeight: CGFloat) {
-        guard numberOfLines == 0, let text = text else {
+        guard let text else {
             return
         }
         let paragraphStyle = NSMutableParagraphStyle()


### PR DESCRIPTION
## 解決したいこと
- TypographiesでnumberOfLinesが0の時にlineSpacingが設定されるようになっているが、2などを設定したときにlineSpacingが設定されない

## やったこと
- UIKit版の分岐を削除
- SwiftUI版でも不要な分岐を削除

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
