### PR TITLE
Fix text truncation for single-line text in UIKit

### DIFF
--- a/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
+++ b/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
@@ -18,7 +18,8 @@ extension UILabel {
     }
 
     func setupLineHeight(lineHeight: CGFloat) {
-        guard let text else {
+        // If set for a single line, text truncation will not work.
+        guard numberOfLines != 1, let text else {
             return
         }
         let paragraphStyle = NSMutableParagraphStyle()


### PR DESCRIPTION
## 解決したいこと
- https://github.com/pixiv/charcoal-ios/pull/318 の変更でUIKitにおけるTypographyの1行表示の縮小表示が壊れていた

## やったこと
- 1行の時はline spacingを設定しないように

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---
![typography_before](https://github.com/user-attachments/assets/d8a09e83-ebbe-4c2d-999c-5c8aab878863) | ![typography_after](https://github.com/user-attachments/assets/d7d46031-3eb5-4539-8d6b-7893094a5046)


## 動作確認環境
- 
