### PR TITLE
Use rect(cornerRadius:) for Capsule on iOS 15 and below

### DIFF
--- a/Sources/CharcoalSwiftUI/Components/Buttons/CapsuleShape.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CapsuleShape.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+extension Shape where Self == RoundedRectangle {
+    // Using rect(cornerRadius:) because the standard Capsule doesn't work correctly on iOS 15 and below.
+    public static var charcoalCapsule: Self {
+        return .rect(cornerRadius: 9999)
+    }
+}

--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalDefaultButton.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalDefaultButton.swift
@@ -30,7 +30,7 @@ struct CharcoalDefaultButtonStyleView: View {
                 Rectangle()
                     .backport.foregroundStyle(isPressed ? Color(CharcoalAsset.ColorPaletteGenerated.surface10.color) : .clear)
             )
-            .clipShape(.capsule)
+            .clipShape(.charcoalCapsule)
             .hoverEffect(.lift)
     }
 }

--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalDefaultOverlay.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalDefaultOverlay.swift
@@ -30,7 +30,7 @@ struct CharcoalDefaultOverlayButtonStyleView: View {
                 Rectangle()
                     .backport.foregroundStyle(isPressed ? Color(CharcoalAsset.ColorPaletteGenerated.surface10.color) : .clear)
             )
-            .clipShape(.capsule)
+            .clipShape(.charcoalCapsule)
             .hoverEffect(.lift)
     }
 }

--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalPrimaryButton.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalPrimaryButton.swift
@@ -32,7 +32,7 @@ struct CharcoalPrimaryButtonStyleView: View {
                 Rectangle()
                     .backport.foregroundStyle(isPressed ? Color(CharcoalAsset.ColorPaletteGenerated.surface10.color) : .clear)
             )
-            .clipShape(.capsule)
+            .clipShape(.charcoalCapsule)
             .hoverEffect(.lift)
     }
 }


### PR DESCRIPTION
## 解決したいこと
- iOS 15以下でButtonの形状が崩れている

## やったこと
- Capsuleの代わりに `rect(cornerRadius:)` を使用

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---
![button_before](https://github.com/user-attachments/assets/415b750f-e7a4-46df-b0b8-d0e6436b0d2a) | ![button_ater](https://github.com/user-attachments/assets/1d9b9b74-d3fc-44ab-8fa7-064220cf8eaa)

## 動作確認環境


- 
