### PR TITLE
iOS 26由来のcharcoalTypographyにおける名前衝突を修正

### DIFF
--- a/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypography12.swift
+++ b/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypography12.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
-private let fontSize = CGFloat(charcoalFoundation.typography.size.the12.fontSize)
-private let lineHeight = CGFloat(charcoalFoundation.typography.size.the12.lineHeight)
+private let the12FontSize = CGFloat(charcoalFoundation.typography.size.the12.fontSize)
+private let the12LineHeight = CGFloat(charcoalFoundation.typography.size.the12.lineHeight)
 
 public extension View {
     func charcoalTypography12Bold(isSingleLine: Bool = false) -> some View {
         return modifier(CharcoalFontModifier(
-            size: fontSize,
+            size: the12FontSize,
             weight: .bold,
-            lineHeight: lineHeight,
+            lineHeight: the12LineHeight,
             isSingleLine: isSingleLine,
             textStyle: .body
         ))
@@ -16,9 +16,9 @@ public extension View {
 
     func charcoalTypography12Regular(isSingleLine: Bool = false) -> some View {
         return modifier(CharcoalFontModifier(
-            size: fontSize,
+            size: the12FontSize,
             weight: .regular,
-            lineHeight: lineHeight,
+            lineHeight: the12LineHeight,
             isSingleLine: isSingleLine,
             textStyle: .body
         ))
@@ -26,7 +26,7 @@ public extension View {
 
     func charcoalTypography12BoldMono() -> some View {
         return modifier(CharcoalMonoFontModifier(
-            size: fontSize,
+            size: the12FontSize,
             weight: .bold,
             textStyle: .body
         ))
@@ -34,7 +34,7 @@ public extension View {
 
     func charcoalTypography12RegularMono() -> some View {
         return modifier(CharcoalMonoFontModifier(
-            size: fontSize,
+            size: the12FontSize,
             weight: .regular,
             textStyle: .body
         ))

--- a/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypography14.swift
+++ b/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypography14.swift
@@ -1,37 +1,37 @@
 import SwiftUI
 
-private let fontSize = CGFloat(charcoalFoundation.typography.size.the14.fontSize)
-private let lineHeight = CGFloat(charcoalFoundation.typography.size.the14.lineHeight)
+private let the14FontSize = CGFloat(charcoalFoundation.typography.size.the14.fontSize)
+private let the14LineHeight = CGFloat(charcoalFoundation.typography.size.the14.lineHeight)
 
 public extension View {
     func charcoalTypography14Bold(isSingleLine: Bool = false) -> some View {
         return modifier(CharcoalFontModifier(
-            size: fontSize,
+            size: the14FontSize,
             weight: .bold,
-            lineHeight: lineHeight,
+            lineHeight: the14LineHeight,
             isSingleLine: isSingleLine
         ))
     }
 
     func charcoalTypography14Regular(isSingleLine: Bool = false) -> some View {
         return modifier(CharcoalFontModifier(
-            size: fontSize,
+            size: the14FontSize,
             weight: .regular,
-            lineHeight: lineHeight,
+            lineHeight: the14LineHeight,
             isSingleLine: isSingleLine
         ))
     }
 
     func charcoalTypography14BoldMono() -> some View {
         return modifier(CharcoalMonoFontModifier(
-            size: fontSize,
+            size: the14FontSize,
             weight: .bold
         ))
     }
 
     func charcoalTypography14RegularMono() -> some View {
         return modifier(CharcoalMonoFontModifier(
-            size: fontSize,
+            size: the14FontSize,
             weight: .regular
         ))
     }

--- a/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypography16.swift
+++ b/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypography16.swift
@@ -1,37 +1,37 @@
 import SwiftUI
 
-private let fontSize = CGFloat(charcoalFoundation.typography.size.the16.fontSize)
-private let lineHeight = CGFloat(charcoalFoundation.typography.size.the16.lineHeight)
+private let the16FontSize = CGFloat(charcoalFoundation.typography.size.the16.fontSize)
+private let the16LineHeight = CGFloat(charcoalFoundation.typography.size.the16.lineHeight)
 
 public extension View {
     func charcoalTypography16Bold(isSingleLine: Bool = false) -> some View {
         return modifier(CharcoalFontModifier(
-            size: fontSize,
+            size: the16FontSize,
             weight: .bold,
-            lineHeight: lineHeight,
+            lineHeight: the16LineHeight,
             isSingleLine: isSingleLine
         ))
     }
 
     func charcoalTypography16Regular(isSingleLine: Bool = false) -> some View {
         return modifier(CharcoalFontModifier(
-            size: fontSize,
+            size: the16FontSize,
             weight: .regular,
-            lineHeight: lineHeight,
+            lineHeight: the16LineHeight,
             isSingleLine: isSingleLine
         ))
     }
 
     func charcoalTypography16BoldMono() -> some View {
         return modifier(CharcoalMonoFontModifier(
-            size: fontSize,
+            size: the16FontSize,
             weight: .bold
         ))
     }
 
     func charcoalTypography16RegularMono() -> some View {
         return modifier(CharcoalMonoFontModifier(
-            size: fontSize,
+            size: the16FontSize,
             weight: .regular
         ))
     }

--- a/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypograpy20.swift
+++ b/Sources/CharcoalSwiftUI/Components/Typographies/CharcoalTypograpy20.swift
@@ -1,37 +1,37 @@
 import SwiftUI
 
-private let fontSize = CGFloat(charcoalFoundation.typography.size.the20.fontSize)
-private let lineHeight = CGFloat(charcoalFoundation.typography.size.the20.lineHeight)
+private let the20FontSize = CGFloat(charcoalFoundation.typography.size.the20.fontSize)
+private let the20LineHeight = CGFloat(charcoalFoundation.typography.size.the20.lineHeight)
 
 public extension View {
     func charcoalTypography20Bold(isSingleLine: Bool = false) -> some View {
         return modifier(CharcoalFontModifier(
-            size: fontSize,
+            size: the20FontSize,
             weight: .bold,
-            lineHeight: lineHeight,
+            lineHeight: the20LineHeight,
             isSingleLine: isSingleLine
         ))
     }
 
     func charcoalTypography20Regular(isSingleLine: Bool = false) -> some View {
         return modifier(CharcoalFontModifier(
-            size: fontSize,
+            size: the20FontSize,
             weight: .regular,
-            lineHeight: lineHeight,
+            lineHeight: the20LineHeight,
             isSingleLine: isSingleLine
         ))
     }
 
     func charcoalTypography20BoldMono() -> some View {
         return modifier(CharcoalMonoFontModifier(
-            size: fontSize,
+            size: the20FontSize,
             weight: .bold
         ))
     }
 
     func charcoalTypography20RegularMono() -> some View {
         return modifier(CharcoalMonoFontModifier(
-            size: fontSize,
+            size: the20FontSize,
             weight: .regular
         ))
     }


### PR DESCRIPTION
## 解決したいこと
- iOS 26で`View`に`nonisolated public func lineHeight(_ lineHeight: AttributedString.LineHeight?) -> some View`が追加されたことによる`charcoalTypography`の`lineHeight`の名前衝突のためにビルドができない

## やったこと
- 各`charcoalTypography`の`lineHeight`に`the12`のようなプレフィックスを追加した
- 伴って、`fontSize`にも同様のプレフィックスを追加した

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
-
