### PR TITLE
UIKitのCharcoalTypographyの`numberOfLine`を変更した際に、lineHeightが適切に設定されてない不具合を修正

### DIFF
--- a/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
+++ b/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
@@ -44,7 +44,7 @@ extension CharcoalTypographyStyle where Self: UILabel {
         if isMono {
             numberOfLines = 1
         } else {
-            setupLineHeight(lineHeight: lineHeight)
+            setupParagraphStyle(lineHeight: lineHeight, alignment: textAlignment)
         }
     }
 }

--- a/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
+++ b/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
@@ -36,10 +36,9 @@ public class CharcoalTypographyLabel: UILabel, CharcoalTypographyStyle {
         setupStyle()
     }
 
-    public override var numberOfLines: Int {
-        didSet {
-            setupStyle()
-        }
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        setupStyle()
     }
 }
 

--- a/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
+++ b/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
@@ -35,6 +35,12 @@ public class CharcoalTypographyLabel: UILabel, CharcoalTypographyStyle {
         super.awakeFromNib()
         setupStyle()
     }
+
+    public override var numberOfLines: Int {
+        didSet {
+            setupStyle()
+        }
+    }
 }
 
 extension CharcoalTypographyStyle where Self: UILabel {

--- a/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
+++ b/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
@@ -17,7 +17,7 @@ extension UILabel {
         }
     }
 
-    func setupLineHeight(lineHeight: CGFloat) {
+    func setupParagraphStyle(lineHeight: CGFloat, alignment: NSTextAlignment) {
         // If set for a single line, text truncation will not work.
         guard numberOfLines != 1, let text else {
             return
@@ -27,6 +27,7 @@ extension UILabel {
         let range = NSRange(location: 0, length: attributedText.length)
 
         paragraphStyle.lineSpacing = lineHeight - font.lineHeight
+        paragraphStyle.alignment = alignment
         attributedText.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
 
         self.attributedText = attributedText


### PR DESCRIPTION
## 解決したいこと
- UIKitのCharcoalTypographyの`numberOfLine`を変更した際に、lineHeightが適切に設定されてない

現在の実装では`numberOfLine`を変更するだけでは`setupLineHeight(lineHeight:)`が実行されないため、複数行であるにもかかわらずlineHeightがCharcoalTypographyの期待する高さにならないことがある。

## やったこと
- `layoutSubviews()`時、`setupLineHeight(lineHeight:)`が実行されるようにした

## やらないこと
- 根本的なアーキテクチャ変更

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---
<img src="https://github.com/user-attachments/assets/cda8df51-97dc-47f3-990d-3056683ef389">|<img src="https://github.com/user-attachments/assets/7917db3d-bce2-43be-8618-3073e85dd30d">

## 動作確認環境
- Xcode 16.4
