### PR TITLE
UIKitのCharcoalTypographyの`textAlignment`が、設定順等の理由で適用されないことがある不具合を修正

### DIFF
--- a/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
+++ b/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
@@ -44,7 +44,7 @@ extension CharcoalTypographyStyle where Self: UILabel {
         if isMono {
             numberOfLines = 1
         } else {
-            setupLineHeight(lineHeight: lineHeight, alignment: textAlignment)
+            setupParagraphStyle(lineHeight: lineHeight, alignment: textAlignment)
         }
     }
 }

--- a/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
+++ b/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
@@ -17,7 +17,7 @@ extension UILabel {
         }
     }
 
-    func setupLineHeight(lineHeight: CGFloat, alignment: NSTextAlignment) {
+    func setupParagraphStyle(lineHeight: CGFloat, alignment: NSTextAlignment) {
         // If set for a single line, text truncation will not work.
         guard numberOfLines != 1, let text else {
             return


### PR DESCRIPTION
## 解決したいこと
- UIKitのCharcoalTypographyの`textAlignment`が、設定順等の理由で適用されないことがある

`setupLineHeight(lineHeight:)`が実行されると、CharcoalTypography内部でNSAttributedTextを使うようになるため、先に設定されていた`textAlignment`が受け継がれない

isBoldより前にtextAlignmentを設定 | isBoldより後にtextAlignmentを設定
---|---
<img width="980" height="547" alt="スクリーンショット 2025-08-04 17 05 54" src="https://github.com/user-attachments/assets/8d5af48c-4ab9-4105-bf57-b5588102bec2" /> | <img width="972" height="551" alt="スクリーンショット 2025-08-04 17 05 16" src="https://github.com/user-attachments/assets/43a5fd3f-1698-43e4-a724-2be722a4f2cc" />


## やったこと
- setupLineHeight(lineHeight:)がNSTextAlignmentを受け継ぐように変更

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

After
<img width="984" height="549" alt="スクリーンショット 2025-08-04 17 12 51" src="https://github.com/user-attachments/assets/5df0f783-58b0-470e-8ec0-f072543fcbdf" />


## 動作確認環境
- Xcode 16.4
