### PR TITLE
UIKitのCharcoalTypographyがUILabelの設定を十分に受け継ぐように修正

### DIFF
--- a/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
+++ b/Sources/CharcoalUIKit/Components/Typography/CharcoalTypographyLabel.swift
@@ -39,12 +39,12 @@ public class CharcoalTypographyLabel: UILabel, CharcoalTypographyStyle {
 
 extension CharcoalTypographyStyle where Self: UILabel {
     func setupStyle() {
-        setupFont(fontSize: fontSize, isBold: isBold, isMono: isMono)
-        adjustsFontForContentSizeCategory = true
         if isMono {
             numberOfLines = 1
-        } else {
-            setupParagraphStyle(lineHeight: lineHeight, alignment: textAlignment)
         }
+
+        setupParagraphStyle(lineHeight: lineHeight)
+        setupFont(fontSize: fontSize, isBold: isBold, isMono: isMono)
+        adjustsFontForContentSizeCategory = true
     }
 }

--- a/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
+++ b/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
@@ -39,15 +39,6 @@ extension UILabel {
         paragraphStyle.allowsDefaultTighteningForTruncation = allowsDefaultTighteningForTruncation
         paragraphStyle.alignment = textAlignment
 
-        switch effectiveUserInterfaceLayoutDirection {
-        case .rightToLeft:
-            paragraphStyle.baseWritingDirection = .rightToLeft
-        case .leftToRight:
-            paragraphStyle.baseWritingDirection = .natural
-        @unknown default:
-            paragraphStyle.baseWritingDirection = .natural
-        }
-
         return paragraphStyle
     }
 }

--- a/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
+++ b/Sources/CharcoalUIKit/Extensions/UILabelExtension.swift
@@ -17,19 +17,37 @@ extension UILabel {
         }
     }
 
-    func setupParagraphStyle(lineHeight: CGFloat, alignment: NSTextAlignment) {
-        // If set for a single line, text truncation will not work.
-        guard numberOfLines != 1, let text else {
+    func setupParagraphStyle(lineHeight: CGFloat) {
+        guard let text else {
             return
         }
-        let paragraphStyle = NSMutableParagraphStyle()
+
+        let paragraphStyle = makeMutableParagraphStyle()
+        paragraphStyle.lineSpacing = lineHeight - font.lineHeight
+
         let attributedText = NSMutableAttributedString(string: text)
         let range = NSRange(location: 0, length: attributedText.length)
-
-        paragraphStyle.lineSpacing = lineHeight - font.lineHeight
-        paragraphStyle.alignment = alignment
         attributedText.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
 
         self.attributedText = attributedText
+    }
+
+    private func makeMutableParagraphStyle() -> NSMutableParagraphStyle {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = lineBreakMode
+        paragraphStyle.lineBreakStrategy = lineBreakStrategy
+        paragraphStyle.allowsDefaultTighteningForTruncation = allowsDefaultTighteningForTruncation
+        paragraphStyle.alignment = textAlignment
+
+        switch effectiveUserInterfaceLayoutDirection {
+        case .rightToLeft:
+            paragraphStyle.baseWritingDirection = .rightToLeft
+        case .leftToRight:
+            paragraphStyle.baseWritingDirection = .natural
+        @unknown default:
+            paragraphStyle.baseWritingDirection = .natural
+        }
+
+        return paragraphStyle
     }
 }


### PR DESCRIPTION
## 解決したいこと
- UIKitのCharcoalTypographyがUILabelの設定を十分に受け継ぐようにしたい
  - textAlignment
  - lineBreakMode
  - etc..

## やったこと
- UILabelの設定を受け継ぐNSMutableParagraphStyleを生成するように

## やらないこと
- RTLの適切な設定の考慮

Geminiによると以下のような実装を行うことで適切にRTLも考慮できるらしいが、十分な理解と検証を行えていないため、このPRでは扱わない
```swift
func setupParagraphStyle(lineHeight: CGFloat) {
        // ...

        switch effectiveUserInterfaceLayoutDirection {
        case .rightToLeft:
            paragraphStyle.baseWritingDirection = .rightToLeft
        case .leftToRight:
            paragraphStyle.baseWritingDirection = .natural
        @unknown default:
            paragraphStyle.baseWritingDirection = .natural
        }
}
```

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

既存実装
<img width="1520" height="384" alt="スクリーンショット 2025-08-06 11 43 27" src="https://github.com/user-attachments/assets/6236f8ea-e50d-4845-80e9-a2113a6dfd50" />

既存実装で、guard numberOfLine == 1 を取り除いた場合
<img width="1519" height="388" alt="スクリーンショット 2025-08-06 11 43 56" src="https://github.com/user-attachments/assets/9af33c69-3f5a-4684-b2ee-9e8ced5c92af" />

今回の変更
<img width="1520" height="387" alt="スクリーンショット 2025-08-06 11 44 48" src="https://github.com/user-attachments/assets/3b91b735-d1c4-4928-ac84-cc99e1bc0706" />

## 動作確認環境
- Xcode 16.4
