### PR TITLE
Fix NavigationButton style

### DIFF
--- a/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalNavigationButton.swift
+++ b/Sources/CharcoalSwiftUI/Components/Buttons/CharcoalNavigationButton.swift
@@ -35,7 +35,7 @@ struct CharcoalNavigationButtonStyleView: View {
                 Rectangle()
                     .backport.foregroundStyle(isPressed ? Color(CharcoalAsset.ColorPaletteGenerated.surface10.color) : .clear)
             )
-            .clipShape(.capsule)
+            .clipShape(.charcoalCapsule)
             .hoverEffect(.lift)
         )
     }


### PR DESCRIPTION
## 解決したいこと
- SwiftUIのNavigationButtonがcapsuleになっていない

## やったこと
- https://github.com/pixiv/charcoal-ios/pull/324 と同じように修正

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
