### PR TITLE
iOS26でのトグルアニメーション修正

### DIFF
--- a/Sources/CharcoalSwiftUI/Components/CharcoalToggle.swift
+++ b/Sources/CharcoalSwiftUI/Components/CharcoalToggle.swift
@@ -19,10 +19,6 @@ struct CharcoalToggleWrapper: UIViewRepresentable {
 
     func updateUIView(_ uiView: UISwitch, context _: Context) {
         if uiView.isOn != isOn {
-            uiView.onTintColor = CharcoalAsset.ColorPaletteGenerated.brand.color
-            uiView.backgroundColor = CharcoalAsset.ColorPaletteGenerated.surface4.color
-            uiView.layer.cornerRadius = uiView.frame.size.height / 2.0
-            uiView.layer.cornerCurve = .continuous
             uiView.isOn = isOn
         }
     }


### PR DESCRIPTION
## 解決したいこと
- iOS26でトグルのアニメーションが動作しない

## やったこと
- 値が変化したときだけviewのパラメータを設定する

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
