### PR TITLE
CharcoalToggleのON/OFFが外部から変更された際にもアニメーションするように修正

### DIFF
--- a/Sources/CharcoalSwiftUI/Components/CharcoalToggle.swift
+++ b/Sources/CharcoalSwiftUI/Components/CharcoalToggle.swift
@@ -19,7 +19,7 @@ struct CharcoalToggleWrapper: UIViewRepresentable {
 
     func updateUIView(_ uiView: UISwitch, context _: Context) {
         if uiView.isOn != isOn {
-            uiView.isOn = isOn
+            uiView.setOn(isOn, animated: true)
         }
     }
 


### PR DESCRIPTION
## 解決したいこと
- 下記のコードのように外部から状態が変更された際に、アニメーションせずにカクッと変化してしまう

```swift
@available(iOS 17, *)
#Preview {
    @Previewable @State var isOn = false

    HStack {
        Button {
            isOn.toggle()
        } label: {
            Text("Toggle")
        }

        Toggle(isOn: $isOn) {}
            .charcoalToggle()
    }
}
```

## やったこと
- 外部から状態を変更される際にアニメーションさせる

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---
![画面収録 2025-10-07 5 00 37](https://github.com/user-attachments/assets/b78f82ed-3934-491f-9177-040332a2394d) | ![画面収録 2025-10-07 5 00 14](https://github.com/user-attachments/assets/c784b070-5b84-4bef-9b28-d13e52a73d89)


## 動作確認環境
- Xcode 16.4
