### PR TITLE
Add non-auto-dismissing Toast and SnackBar variants for UI tests

### DIFF
--- a/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/ToastsView.swift
+++ b/CharcoalSwiftUISample/Sources/CharcoalSwiftUISample/ToastsView.swift
@@ -22,8 +22,7 @@ public struct ToastsView: View {
                 }
                 .charcoalSnackBar(
                     isPresenting: $isPresenting,
-                    text: "ブックマークしました",
-                    dismissAfter: 4
+                    text: "ブックマークしました"
                 )
 
                 VStack(alignment: .leading) {
@@ -38,7 +37,6 @@ public struct ToastsView: View {
                     isPresenting: $isPresenting2,
                     screenEdge: .top,
                     text: "ブックマークしました",
-                    dismissAfter: 4,
                     action: {
                         Button {
                             print("Tapped")
@@ -60,7 +58,6 @@ public struct ToastsView: View {
                     isPresenting: $isPresenting3,
                     text: "ブックマークしました",
                     thumbnailImage: Image("SnackbarDemo", bundle: Bundle.module),
-                    dismissAfter: 4,
                     action: {
                         Button {
                             print("Tapped")
@@ -76,16 +73,16 @@ public struct ToastsView: View {
                     } label: {
                         Text("SnackBar")
                     }
-                    Text("Auto dismiss after 4 seconds")
+                    Text("without Auto Dismiss")
                 }
                 .charcoalSnackBar(
                     isPresenting: $isPresenting4,
                     text: "ブックマークしました",
                     thumbnailImage: Image("SnackbarDemo", bundle: Bundle.module),
-                    dismissAfter: 4,
+                    dismissAfter: nil,
                     action: {
                         Button {
-                            print("Tapped")
+                            isPresenting4 = false
                         } label: {
                             Text("編集")
                         }
@@ -101,8 +98,7 @@ public struct ToastsView: View {
                 }
                 .charcoalToast(
                     isPresenting: $isPresentingToast,
-                    text: "テキストメッセージ",
-                    dismissAfter: 4
+                    text: "テキストメッセージ"
                 )
 
                 VStack(alignment: .leading) {
@@ -117,7 +113,6 @@ public struct ToastsView: View {
                     isPresenting: $isPresentingToast2,
                     screenEdge: .top,
                     text: "テキストメッセージ",
-                    dismissAfter: 4,
                     action: {
                         Button {
                             isPresentingToast2 = false
@@ -139,7 +134,6 @@ public struct ToastsView: View {
                 .charcoalToast(
                     isPresenting: $isPresentingToast3,
                     text: "ブックマークしました",
-                    dismissAfter: 4,
                     appearance: .error,
                     animationConfiguration: CharcoalToastAnimationConfiguration(enablePositionAnimation: false, animation: .easeInOut),
                     action: {
@@ -156,15 +150,22 @@ public struct ToastsView: View {
                     Button {
                         isPresentingToast4.toggle()
                     } label: {
-                        Text("Toast(Error Appearance)")
+                        Text("Toast")
                     }
-                    Text("Auto dismiss after 4 seconds")
+                    Text("without Auto Dismiss")
                 }
                 .charcoalToast(
                     isPresenting: $isPresentingToast4,
-                    text: "ブックマークしました",
-                    dismissAfter: 4,
-                    appearance: .error
+                    text: "テキストメッセージ",
+                    dismissAfter: nil,
+                    action: {
+                        Button {
+                            isPresentingToast4 = false
+                        } label: {
+                            Image(charcoalIcon: .remove16)
+                                .renderingMode(.template)
+                        }
+                    }
                 )
             }
         }.navigationBarTitle("Toasts")

--- a/CharcoalUIKitSample/Sources/CharcoalUIKitSample/Views/Toasts/Toasts.swift
+++ b/CharcoalUIKitSample/Sources/CharcoalUIKitSample/Views/Toasts/Toasts.swift
@@ -5,6 +5,7 @@ enum SnackbarTitles: String, CaseIterable {
     case normal = "Normal"
     case withAction = "with Action"
     case withActionAndThumbnail = "with Action and Thumbnail"
+    case withoutAutoDismiss = "without Auto Dismiss"
 
     var text: String {
         return "ブックマークしました"
@@ -20,6 +21,7 @@ enum ToastsTitles: String, CaseIterable {
     case normal = "Normal"
     case normalWithAction = "with Action"
     case errorWithAction = "error with Action"
+    case withoutAutoDismiss = "without Auto Dismiss"
 
     var text: String {
         switch self {
@@ -29,6 +31,8 @@ enum ToastsTitles: String, CaseIterable {
             return "Hello World This is a tooltip with mutiple line"
         case .errorWithAction:
             return "こんにちは This is a tooltip and here is testing it's multiple line feature"
+        case .withoutAutoDismiss:
+            return "Hello World"
         }
     }
 
@@ -127,6 +131,7 @@ extension ToastsViewController: UITableViewDelegate, UITableViewDataSource {
             let titleCase = ToastsTitles.allCases[indexPath.row]
 
             var toastID: CharcoalIdentifiableOverlayView.IDValue
+            var shouldAutoDismiss = true
             switch titleCase {
             case .normal:
                 toastID = CharcoalToast.show(text: titleCase.text, screenEdge: .top)
@@ -143,15 +148,24 @@ extension ToastsViewController: UITableViewDelegate, UITableViewDataSource {
                         print("Clicked on action")
                     }
                 )
+            case .withoutAutoDismiss:
+                toastID = CharcoalToast.show(text: titleCase.text, screenEdge: .bottom, actionCallback: {
+                    print("Clicked on action")
+                })
+                shouldAutoDismiss = false
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-                CharcoalToast.dismiss(id: toastID)
+            if shouldAutoDismiss {
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    CharcoalToast.dismiss(id: toastID)
+                }
             }
         case .snackbars:
             let titleCase = SnackbarTitles.allCases[indexPath.row]
 
             var toastID: CharcoalIdentifiableOverlayView.IDValue
+            var shouldAutoDismiss = true
             switch titleCase {
             case .normal:
                 toastID = CharcoalSnackBar.show(text: titleCase.text, screenEdge: .top)
@@ -163,10 +177,18 @@ extension ToastsViewController: UITableViewDelegate, UITableViewDataSource {
                 toastID = CharcoalSnackBar.show(text: titleCase.text, thumbnailImage: UIImage(named: "SnackbarDemo", in: Bundle.module, with: nil), screenEdge: .bottom, action: CharcoalAction(title: "編集", actionCallback: {
                     print("Tapped 編集")
                 }))
+            case .withoutAutoDismiss:
+                toastID = CharcoalSnackBar.show(text: titleCase.text, thumbnailImage: UIImage(named: "SnackbarDemo", in: Bundle.module, with: nil), screenEdge: .bottom, action: CharcoalAction(title: "編集", actionCallback: {
+                    print("Tapped 編集")
+                }))
+                shouldAutoDismiss = false
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-                CharcoalSnackBar.dismiss(id: toastID)
+            if shouldAutoDismiss {
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    CharcoalSnackBar.dismiss(id: toastID)
+                }
             }
         }
     }


### PR DESCRIPTION
## 解決したいこと
- Stabilize Toast/SnackBar behavior for UI tests.

## やったこと
- Added without Auto Dismiss Toast/SnackBar items in UIKit and SwiftUI.

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
