### PR TITLE
ci: Set cooldown in dependabot :dependabot:

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,23 +4,35 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/scripts/create-pull-request"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/scripts/foundation-gen"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/scripts/xcasset-gen"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "swift"
     directory: "/BuildTools"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## 解決したいこと
昨今サプライチェーンアタックにより依存パッケージの最新版が汚染されることも珍しくないため、仮に依存パッケージが汚染されていてもリポジトリのCIで使われないようにしたい。（dependabotでバージョンアップPRが作られて、それに対応するCIが実行されるだけでアウト）

## やったこと
dependabotにcooldownを設定して最新版が出てもアップデートを7日間待つようにしました。

c.f. https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

## やらないこと
あと別件ですがGitHub Actionsで使ってるactionもSHA Pinを行った方がよさそうなんですが、やっていいかどうかの判断がつかなかったので保留にしてます。（対応は一瞬なんだけど差分がそこそこデカい）

c.f. https://zenn.dev/azu/articles/ad168118524135#github-actions%E3%81%A7%E3%81%AFsha-pin%E3%82%92%E8%A1%8C%E3%81%86


## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
